### PR TITLE
Use reduce() instead of sortByKey() to find boundaries in localcorr

### DIFF
--- a/python/thunder/sigprocessing/localcorr.py
+++ b/python/thunder/sigprocessing/localcorr.py
@@ -47,10 +47,12 @@ def localcorr(data, sz):
     """
 
     # get boundaries
-    mx_x = data.map(lambda (k, v): (k[0], 1)).sortByKey(False).first()[0]
-    mn_x = data.map(lambda (k, v): (k[0], 1)).sortByKey(True).first()[0]
-    mx_y = data.map(lambda (k, v): (k[1], 1)).sortByKey(False).first()[0]
-    mn_y = data.map(lambda (k, v): (k[1], 1)).sortByKey(True).first()[0]
+    xs = data.map(lambda (k, _): k[0])
+    ys = data.map(lambda (k, _): k[1])
+    mx_x = xs.reduce(max)
+    mn_x = xs.reduce(min)
+    mx_y = ys.reduce(max)
+    mn_y = ys.reduce(min)
 
     # flat map to key value pairs where the key is neighborhood identifier and value is time series
     neighbors = data.flatMap(lambda (k, v): maptoneighborhood(k, v, sz, mn_x, mx_x, mn_y, mx_y))


### PR DESCRIPTION
This change uses `reduce()` instead of `sortByKey()` to calculate the boundaries in `localcorr`.

Sorting is an expensive operation in Spark since it executes two jobs, one to compute ranges to achieve a balanced range partitioning, and another to actually shuffle and sort the data.

Reduce will be significantly more efficient, since it's effectively calculating the minimum or maximum value of each partition, then taking the minimum or maximum of those values.

There's still room to improve performance by computing all four boundaries in a single pass, but I decided to wait until I've written a clean "run multiple reductions in parallel" abstraction before implementing that.
