### PR TITLE
Custom rdds: ordering of points within series block 

### DIFF
--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -357,6 +357,9 @@ class TestImageBlockValue(unittest.TestCase):
             expectedkv = (ij[0], ij[1]), arange(n, n+4, dtype='int16')
             expectedseries.append(expectedkv)
 
+        # reverse order of expectedseries so that first dim is changing most rapidly
+        expectedseries.sort(key=lambda kv: tuple(reversed(kv[0])))
+
         for actual, expected in zip(series, expectedseries):
             # check key equality
             assert_equals(expected[0], actual[0])

--- a/python/thunder/rdds/images.py
+++ b/python/thunder/rdds/images.py
@@ -880,8 +880,10 @@ class ImageBlockValue(object):
         del rangeiters[seriesDim]
         # correct for original dimensionality if inserting at end of list
         insertDim = seriesDim if seriesDim >= 0 else len(self.origshape) + seriesDim
-        for idxSeq in itertools.product(*rangeiters):
-            expandedIdxSeq = list(idxSeq[:])
+        # reverse rangeiters twice to ensure that first dimension is most rapidly varying
+        for idxSeq in itertools.product(*reversed(rangeiters)):
+            idxSeq = tuple(reversed(idxSeq))
+            expandedIdxSeq = list(idxSeq)
             expandedIdxSeq.insert(insertDim, None)
             slices = []
             for d, (idx, origslice) in enumerate(zip(expandedIdxSeq, self.origslices)):


### PR DESCRIPTION
change ordering of series in block so that first dimension varies fastest
