### PR TITLE
[THUNDER-48] Explicitly specify Hadoop dependency

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -8,6 +8,8 @@ ivyXML := <dependency org="org.eclipse.jetty.orbit" name="javax.servlet" rev="3.
 <artifact name="javax.servlet" type="orbit" ext="jar"/>
 </dependency>
 
+libraryDependencies += "org.apache.hadoop" %% "hadoop-client" % "1.0.4"
+
 libraryDependencies += "org.apache.spark" %% "spark-core" % "1.1.0"
 
 libraryDependencies += "org.apache.spark" %% "spark-streaming" % "1.1.0"


### PR DESCRIPTION
While the build instructions for the scala code are not yet explicit, sbt does a bit of magic to pull the Hadoop version from Spark, which defaults to 1.0.4 at the moment.  This change at least makes the version explicit, so the user can know to change it if desired.

Fixes #48 (kinda)
