### PR TITLE
0.4.x: statcounter

### DIFF
--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -207,17 +207,6 @@ class Data(object):
         """
         return self.stats('stdev', dtype=dtype, casting=casting).stdev()
 
-    # def stats(self, dtype='smallfloat', casting='safe'):
-    #     """ Stats of values, ignoring keys
-    #
-    #     If dtype is not None, then the values will first be cast to the requested type before the operation is
-    #     performed. See Data.astype() for details.
-    #
-    #     obj.stats() is equivalent to obj.astype(dtype, casting).rdd.values().stats().
-    #     """
-    #     out = self.astype(dtype, casting)
-    #     return out.rdd.values().stats()
-
     def stats(self, requestedStats='all', dtype='smallfloat', casting='safe'):
         """
         Return a L{StatCounter} object that captures all or some of the mean, variance, maximum, minimum,

--- a/python/thunder/utils/statcounter.py
+++ b/python/thunder/utils/statcounter.py
@@ -16,7 +16,8 @@
 #
 
 # This file is ported from spark/util/StatCounter.scala
-# Modified from pyspark's statcounter.py.
+#
+# This code is based on pyspark's statcounter.py and used under the ASF 2.0 license.
 
 import copy
 import math


### PR DESCRIPTION
This PR adds a statcounter.py file based on that in pyspark, but with the additional optimization that only those values necessary for the requested statistics will be updated (so, for instance, we won't update the `m2`  variable, which is required for `stdev` and `variance`, if the only stat that we're trying to calculate is the mean).

Please note we've already got unit test coverage for the methods affected by this change, in test_images.py TestImagesStats.

This is a fix for #60.
