### PR TITLE
EC2 script changes for spark 1.2.0

### DIFF
--- a/python/thunder/utils/ec2.py
+++ b/python/thunder/utils/ec2.py
@@ -28,6 +28,8 @@ import sys
 import os
 import random
 import subprocess
+import time
+from distutils.version import LooseVersion
 from sys import stderr
 from optparse import OptionParser
 from spark_ec2 import launch_cluster, get_existing_cluster, stringify_command, \
@@ -35,10 +37,10 @@ from spark_ec2 import launch_cluster, get_existing_cluster, stringify_command, \
 
 try:
     from spark_ec2 import wait_for_cluster
-    spark_110 = True
 except ImportError:
     from spark_ec2 import wait_for_cluster_state
-    spark_110 = False
+
+MINIMUM_SPARK_VERSION = "1.1.0"
 
 
 def get_s3_keys():
@@ -54,7 +56,51 @@ def get_s3_keys():
     return s3_access_key, s3_secret_key
 
 
-def install_thunder(master, opts):
+def get_spark_version_string(default_version):
+    """ Parses out the Spark version string from $SPARK_HOME/RELEASE, if present, or from pom.xml if not
+
+    Returns version string from either of the above sources, or default_version if nothing else works
+    """
+    SPARK_HOME = os.getenv("SPARK_HOME")
+    if SPARK_HOME is None:
+        raise Exception('must assign the environmental variable SPARK_HOME with the location of Spark')
+    if os.path.isfile(os.path.join(SPARK_HOME, "RELEASE")):
+        with open(os.path.join(SPARK_HOME, "RELEASE")) as f:
+            line = f.read()
+        # some nasty ad-hoc parsing here. we expect a string of the form "Spark VERSION built for hadoop HADOOP_VERSION"
+        # where VERSION is a dotted version string.
+        # for now, simply check that there are at least two tokens and the second token contains a period.
+        tokens = line.split()
+        if len(tokens) >= 2 and '.' in tokens[1]:
+            return tokens[1]
+    # if we get to this point, we've failed to parse out a version string from the RELEASE file. note that
+    # there will not be a RELEASE file for versions of Spark built from source. in this case we'll try to
+    # get it out from the pom file.
+    import xml.etree.ElementTree as ET
+    try:
+        root = ET.parse(os.path.join(SPARK_HOME, "pom.xml"))
+        version_elt = root.find("/{http://maven.apache.org/POM/4.0.0}version")
+        if version_elt:
+            return version_elt.text
+    except IOError:
+        # no pom file; fall through and return default
+        pass
+    return default_version
+
+SPARK_VERSIONS_TO_HASHES = {
+    '1.2.0': "1056e9ec13"  # spark 1.2.0 rc1, remove once Spark is released and mesos/spark-ec2 is updated
+}
+
+
+def remap_spark_version_to_hash(user_version_string):
+    """Replaces a user-specified Spark version string with a github hash if needed.
+
+    Used to allow clusters to be deployed with Spark release candidates.
+    """
+    return SPARK_VERSIONS_TO_HASHES.get(user_version_string, user_version_string)
+
+
+def install_thunder(master, opts, spark_home_loose_version):
     """ Install Thunder and dependencies on a Spark EC2 cluster"""
     print "Installing Thunder on the cluster..."
     # download and build thunder
@@ -96,7 +142,7 @@ def install_thunder(master, opts):
     # "IPython requires Python 2.7+; please install python2.7 or set PYSPARK_PYTHON"
     # should not do this with earlier versions, as it will lead to
     # "java.lang.IllegalArgumentException: port out of range" [SPARK-3772]
-    if not spark_110:
+    if spark_home_loose_version >= LooseVersion("1.2.0"):
         ssh(master, opts, "echo 'export PYSPARK_PYTHON=/usr/bin/ipython' >> /root/.bash_profile")
     ssh(master, opts, "echo 'export PATH=/root/thunder/python/bin:$PATH' >> /root/.bash_profile")
     # customize spark configuration parameters
@@ -141,8 +187,10 @@ def ssh_args(opts):
         parts += ['-i', opts.identity_file]
     return parts
 
+
 def ssh_command(opts):
     return ['ssh'] + ssh_args(opts)
+
 
 def ssh(host, opts, command):
     tries = 0
@@ -152,10 +200,10 @@ def ssh(host, opts, command):
                 ssh_command(opts) + ['-t', '-t', '%s@%s' % (opts.user, host),
                                      stringify_command(command)])
         except subprocess.CalledProcessError as e:
-            if (tries > 5):
+            if tries > 5:
                 # If this was an ssh failure, provide the user with hints.
                 if e.returncode == 255:
-                    raise UsageError(
+                    raise IOError(
                         "Failed to SSH to remote host {0}.\n" +
                         "Please check that you have provided the correct --identity-file and " +
                         "--key-pair parameters and try again.".format(host))
@@ -207,6 +255,9 @@ def setup_cluster(conn, master_nodes, slave_nodes, opts, deploy_ssh_key):
 
 
 if __name__ == "__main__":
+    spark_home_version_string = get_spark_version_string(MINIMUM_SPARK_VERSION)
+    spark_home_loose_version = LooseVersion(spark_home_version_string)
+
     parser = OptionParser(usage="thunder-ec2 [options] <action> <clustername>",  add_help_option=False)
     parser.add_option("-h", "--help", action="help", help="Show this help message and exit")
     parser.add_option("-k", "--key-pair", help="Key pair to use on instances")
@@ -218,12 +269,15 @@ if __name__ == "__main__":
                       help="Type of instance to launch (default: m3.2xlarge)." +
                            " WARNING: must be 64-bit; small instances won't work")
     parser.add_option("-u", "--user", default="root", help="User name for cluster (default: root)")
+    parser.add_option("-v", "--spark-version", default=spark_home_version_string,
+                      help="Version of Spark to use: 'X.Y.Z' or a specific git hash. (default: %s)" %
+                           spark_home_version_string)
     parser.add_option("-w", "--wait", type="int", default=160,
                       help="Seconds to wait for nodes to start (default: 160)")
     parser.add_option("-z", "--zone", default="", help="Availability zone to launch instances in, or 'all' to spread "
                                                        "slaves across multiple (an additional $0.01/Gb for "
                                                        "bandwidth between zones applies)")
-    parser.add_option("--ssh-port-forwarding", default = None,
+    parser.add_option("--ssh-port-forwarding", default=None,
                       help="Set up ssh port forwarding when you login to the cluster.  " +
                            "This provides a convenient alternative to connecting to iPython " +
                            "notebook over an open port using SSL.  You must supply an argument " +
@@ -233,7 +287,7 @@ if __name__ == "__main__":
                            "maximum price (in dollars)")
     parser.add_option("--resume", default=False, action="store_true",
                       help="Resume installation on a previously launched cluster (for debugging)")
-    if not spark_110:
+    if spark_home_loose_version >= LooseVersion("1.2.0"):
         parser.add_option("--authorized-address", type="string", default="0.0.0.0/0",
                           help="Address to authorize on created security groups (default: %default)" +
                                " (only with Spark >= 1.2.0)")
@@ -249,6 +303,18 @@ if __name__ == "__main__":
         sys.exit(1)
     (action, cluster_name) = args
 
+    spark_version_string = opts.spark_version
+    # check that requested spark version is <= the $SPARK_HOME version, or is a github hash
+    if '.' in spark_version_string:
+        # version string is dotted, not a hash
+        spark_cluster_loose_version = LooseVersion(spark_version_string)
+        if spark_cluster_loose_version > spark_home_loose_version:
+            raise ValueError("Requested cluster Spark version '%s' is greater " % spark_version_string
+                             + "than the local version of Spark in $SPARK_HOME, '%s'" % spark_home_version_string)
+        if spark_cluster_loose_version < LooseVersion(MINIMUM_SPARK_VERSION):
+            raise ValueError("Requested cluster Spark version '%s' is less " % spark_version_string
+                             + "than the minimum version required for Thunder, '%s'" % MINIMUM_SPARK_VERSION)
+
     # The Thunder ec2 scripts hardwire some of the settings that were
     # broken out as command line options in the Spark ec2 scripts.
     opts.ami = get_spark_ami(opts)  # "ami-3ecd0c56"
@@ -256,10 +322,8 @@ if __name__ == "__main__":
     opts.master_instance_type = ""
     opts.hadoop_major_version = "1"
     opts.ganglia = True
-    if spark_110:
-        opts.spark_version = "1.1.0"
-    else:
-        opts.spark_version = "1056e9ec13"  # spark 1.2.0 rc1, change to "1.2.0" once released and mesos/spark-ec2 is updated
+    # get version string as github commit hash if needed (mainly to support Spark release candidates)
+    opts.spark_version = remap_spark_version_to_hash(spark_version_string)
     opts.spark_git_repo = "https://github.com/apache/spark"
     opts.swap = 1024
     opts.worker_instances = 1
@@ -283,9 +347,9 @@ if __name__ == "__main__":
         else:
             (master_nodes, slave_nodes) = launch_cluster(conn, opts, cluster_name)
 
-        if spark_110:
+        try:
             wait_for_cluster(conn, opts.wait, master_nodes, slave_nodes)
-        else:
+        except NameError:
             wait_for_cluster_state(
                 cluster_instances=(master_nodes + slave_nodes),
                 cluster_state='ssh-ready',
@@ -293,7 +357,7 @@ if __name__ == "__main__":
             )
         setup_cluster(conn, master_nodes, slave_nodes, opts, True)
         master = master_nodes[0].public_dns_name
-        install_thunder(master, opts)
+        install_thunder(master, opts, spark_home_loose_version)
         print "\n\n"
         print "-------------------------------"
         print "Cluster successfully launched!"
@@ -346,7 +410,7 @@ if __name__ == "__main__":
 
         # Install thunder on the cluster
         elif action == "install":
-            install_thunder(master, opts)
+            install_thunder(master, opts, spark_home_loose_version)
 
         # Stop a running cluster.  Storage on EBS volumes is
         # preserved, so you can restart the cluster in the same state
@@ -394,7 +458,6 @@ if __name__ == "__main__":
             print "Go to http://%s:8080 to see the web UI for your cluster" % master
             print "-------------------------------"
             print "\n"
-
 
         # Destroy the cluster
         elif action == "destroy":


### PR DESCRIPTION
Changes to thunder-ec2 script for compatibility with the current Spark 1.2.0 rc1 build.

Main new functionality here is a -v/--version parameter to allow the Spark version to be specified, as in the Spark ec2 script on which this is based. The thunder-ec2 script will enforce a minimum requested Spark version of 1.1.0, and a maximum Spark version of whatever is installed locally in $SPARK_HOME. (So if you have 1.1.1 installed locally on the machine from which you are running thunder-ec2, you'll have the option of installing 1.1.0 or 1.1.1, but not 1.2.0.)

Resolves #62.
