### PR TITLE
Added seriesMedian() and seriesPercentile() statistics to the series obj...

### DIFF
--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -1,4 +1,4 @@
-from numpy import ndarray, array, sum, mean, std, size, arange, \
+from numpy import ndarray, array, sum, mean, median, std, size, arange, \
     polyfit, polyval, percentile, asarray, maximum, zeros, corrcoef, where, \
     true_divide, empty_like, ceil
 from numpy import dtype as dtypefunc
@@ -382,6 +382,22 @@ class Series(Data):
         """ Compute the value mean of each record in a Series """
         return self.seriesStat('mean')
 
+    def seriesMedian(self):
+        """ Compute the value median of each record in a Series """
+        return self.seriesStat('median')
+
+    def seriesPercentile(self, q, interpolation = 'linear'):
+        """ Compute the value percentile of each record in a Series.
+        
+        Parameters
+
+          q: a floating point number between 0 and 100 inclusive.
+          interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}  (see documentation for np.percentile)
+        """
+        from numpy import percentile
+        rdd = self.rdd.mapValues(lambda x: percentile(x,q))
+        return self._constructor(rdd, index='percentile').__finalize__(self, nopropagate=('_dtype',))
+
     def seriesStdev(self):
         """ Compute the value std of each record in a Series """
         return self.seriesStat('stdev')
@@ -397,6 +413,7 @@ class Series(Data):
         STATS = {
             'sum': sum,
             'mean': mean,
+            'median': median,
             'stdev': std,
             'max': max,
             'min': min,


### PR DESCRIPTION
This is a pretty straight-forward addition of seriesMedian() and seriesPercentile() to the list of statistics that can be computed for a series object.   These are useful for all sorts of things, but presently I am hoping to use them to stretch the contrast of the data before colormapping it, retaining only the data that falls between the 1% and 99% percentile, and clipping off the few outliers outside of that!

The median (but not the percentile) is also computed when you call the seriesStats() function, since computing the median is not a terribly expensive operation compared the communication overhead involved in getting the results back with Spark. 

The percentile is only available as a seriesPercentile() method, and not as part of the seriesStats(), since it requires an argument (the percentile) to work.  If desired, we could add some pre-computed percentiles (1%, 99%) to the seriesStats() method, but I think its fine to let the user call seriesPercentile() for now.
