### PR TITLE
add wildcard handling to BotoS3FileReader

### DIFF
--- a/python/thunder/rdds/fileio/readers.py
+++ b/python/thunder/rdds/fileio/readers.py
@@ -377,7 +377,7 @@ class BotoS3FileReader(_BotoS3Client):
                         keyname = ""
             keyname += filename
 
-        return _BotoS3Client.retrieveKeys(bucket, keyname)
+        return _BotoS3Client.retrieveKeys(bucket, keyname, prefix=parse[2], postfix=parse[3])
 
     def list(self, datapath, filename=None):
         """List s3 objects specified by datapath.


### PR DESCRIPTION
Fixes #64.

Not easy to set up unit tests for this, short of mocking out the boto library, but here's a before-and-after comparison that I ran:

Before:

``` python
In [1]: from thunder.rdds.fileio.readers import BotoS3FileReader
In [2]: reader = BotoS3FileReader()
In [3]: len(reader.list("s3n://thunder.datasets/test/stack-big/TM*"))
Out[3]: 5503
In [4]: len(reader.list("s3n://thunder.datasets/test/stack-big/*.stack"))
Out[4]: 5503
```

This s3 bucket actually has 5500 `TM*.stack` files, together with a .tif, a .log, and a .xml.

After:

``` python
In [11]: fnames = reader.list("s3n://thunder.datasets/test/stack-big/TM00001*.stack")
In [12]: fnames[:10]
Out[12]: [u's3n:///thunder.datasets/test/stack-big/TM00001_CM0_CHN00.stack']
In [13]: len(reader.list("s3n://thunder.datasets/test/stack-big/"))
Out[13]: 5503
In [14]: len(reader.list("s3n://thunder.datasets/test/stack-big"))
Out[14]: 5503
In [15]: len(reader.list("s3n://thunder.datasets/test/stack-big*.tif"))
Out[15]: 1
In [16]: len(reader.list("s3n://thunder.datasets/test/stack-big/*.tif"))
Out[16]: 1
In [17]: len(reader.list("s3n://thunder.datasets/test/stack-big/*.stack"))
Out[17]: 5500
# ...
In [20]: len(reader.list("s3n://thunder.datasets/test/stack-big/TM*"))
Out[20]: 5500
In [21]: len(reader.list("s3n://thunder.datasets/test/stack-big/", filename="ch0.xml"))
Out[21]: 1
```
