### PR TITLE
Aggregate regions

### DIFF
--- a/python/test/test_series.py
+++ b/python/test/test_series.py
@@ -249,7 +249,7 @@ class TestSeriesMethods(PySparkTestCase):
     def test_meanByRegions_singleRegion(self):
         series, keys, expectedKeys, expected = self.__setup_meanByRegion()
 
-        actualSeries = series.meanByRegions([keys])
+        actualSeries = series.meanByRegion([keys])
         actual = actualSeries.collect()
         assert_equals(1, len(actual))
         assert_equals(expectedKeys, actual[0][0])
@@ -273,7 +273,7 @@ class TestSeriesMethods(PySparkTestCase):
             avgVals = vstack([dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
             expected.append(avgVals)
 
-        actualSeries = series.meanByRegions(nestedKeys)
+        actualSeries = series.meanByRegion(nestedKeys)
         actual = actualSeries.collect()
         assert_equals(2, len(actual))
         for regionIdx in xrange(2):

--- a/python/test/test_series.py
+++ b/python/test/test_series.py
@@ -234,11 +234,15 @@ class TestSeriesMethods(PySparkTestCase):
         itemIdxs = [1, 2]  # data keys for items 1 and 2 (0-based)
         keys = [dataLocal[idx][0] for idx in itemIdxs]
         regionIndices = [keys]
+
+        expectedKeys = tuple(vstack([dataLocal[idx][0] for idx in itemIdxs]).mean(axis=0).astype('int16'))
         expected = vstack([dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
 
-        actual = series.meanByRegions(regionIndices)
+        actualSeries = series.meanByRegions(regionIndices)
+        actual = actualSeries.collect()
         assert_equals(1, len(actual))
-        assert_true(array_equal(expected, actual[0]))
+        assert_equals(expectedKeys, actual[0][0])
+        assert_true(array_equal(expected, actual[0][1]))
 
     def test_maxProject(self):
         from thunder.rdds.fileio.seriesloader import SeriesLoader

--- a/python/test/test_series.py
+++ b/python/test/test_series.py
@@ -238,10 +238,10 @@ class TestSeriesMethods(PySparkTestCase):
         expected = vstack([dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
         return series, keys, expectedKeys, expected
 
-    def test_meanByRegion(self):
+    def test_meanOfRegion(self):
         series, keys, expectedKeys, expected = self.__setup_meanByRegion()
 
-        actual = series.meanByRegion(keys)
+        actual = series.meanOfRegion(keys)
         assert_equals(2, len(actual))
         assert_equals(expectedKeys, actual[0])
         assert_true(array_equal(expected, actual[1]))

--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -561,7 +561,7 @@ class Series(Data):
 
         return keys, values
 
-    def meanByRegion(self, keys):
+    def meanOfRegion(self, keys):
         """Takes the mean of Series values within a single region specified by the passed keys.
 
         Parameters
@@ -570,7 +570,7 @@ class Series(Data):
 
         Returns
         -------
-        tuple of ((mean keys), (mean value))
+        tuple of ((mean of keys), (mean value))
         """
         bcRegionKeys = self.rdd.context.broadcast(frozenset(keys))
         n, kmean, vmean = self.rdd.filter(lambda (k, v): k in bcRegionKeys.value) \

--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -581,14 +581,14 @@ class Series(Data):
         kmean = tuple(kmean.astype('int32'))
         return kmean, vmean
 
-    def meanByRegions(self, nestedKeys):
+    def meanByRegion(self, nestedKeys):
         """Takes the mean of Series values within groupings specified by the passed keys.
 
         Each sequence of keys passed specifies a "region" within which to calculate the mean. For instance,
-        series.aggregateByRegions([[1,2]]) would return the mean of the records in series with key 1 and 2.
+        series.meanByRegion([[(1,0), (2,0)]) would return the mean of the records in series with keys (1,0) and (2,0).
         If multiple regions are passed in, then multiple aggregates will be returned. For instance,
-        series.aggregateByRegions([[1,2], [1,3]]) would return two means, one for the region composed of
-        records 1 and 2, the other for records 1 and 3.
+        series.meanByRegion([[(1,0), (2,0)], [(1,0), (3,0)]]) would return two means, one for the region composed
+        of records (1,0) and (2,0), the other for records (1,0) and (3,0).
 
         Parameters
         ----------


### PR DESCRIPTION
This PR adds two closely-related methods to Series objects, `meanOfRegion` and `meanByRegions`. These calculate the average time series within a set or sets of Series records specified by their keys.