### PR TITLE
Son of Aggregate regions: this is really aggregating

### DIFF
--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -492,8 +492,8 @@ class TestImagesMeanByRegions(PySparkTestCase):
         self.ary2 = array([[13, 15], [16, 18]], dtype='int32')
         self.images = ImagesLoader(self.sc).fromArrays([self.ary1, self.ary2])
 
-    def __checkAttrPropagation(self, newImages):
-        assert_equals(self.images._dims, newImages._dims)
+    def __checkAttrPropagation(self, newImages, newDims):
+        assert_equals(newDims, newImages._dims.count)
         assert_equals(self.images._nimages, newImages._nimages)
         assert_equals(self.images._dtype, newImages._dtype)
 
@@ -504,7 +504,7 @@ class TestImagesMeanByRegions(PySparkTestCase):
     def test_meanWithFloatMask(self):
         mask = array([[1.0, 0.0], [0.0, 1.0]], dtype='float32')
         regionMeanImages = self.images.meanByRegions(mask)
-        self.__checkAttrPropagation(regionMeanImages)
+        self.__checkAttrPropagation(regionMeanImages, (1, 1))
         collected = regionMeanImages.collect()
         assert_equals(2, len(collected))
         assert_equals((1, 1), collected[0][1].shape)
@@ -518,7 +518,7 @@ class TestImagesMeanByRegions(PySparkTestCase):
     def test_meanWithIntMask(self):
         mask = array([[1, 0], [2, 1]], dtype='uint8')
         regionMeanImages = self.images.meanByRegions(mask)
-        self.__checkAttrPropagation(regionMeanImages)
+        self.__checkAttrPropagation(regionMeanImages, (1, 2))
         collected = regionMeanImages.collect()
         assert_equals(2, len(collected))
         assert_equals((1, 2), collected[0][1].shape)
@@ -534,7 +534,7 @@ class TestImagesMeanByRegions(PySparkTestCase):
     def test_meanWithSingleRegionIndices(self):
         indices = [[(0, 0), (0, 1)]]  # one region with two indices
         regionMeanImages = self.images.meanByRegions(indices)
-        self.__checkAttrPropagation(regionMeanImages)
+        self.__checkAttrPropagation(regionMeanImages, (1, 1))
         collected = regionMeanImages.collect()
         assert_equals(2, len(collected))
         assert_equals((1, 1), collected[0][1].shape)
@@ -548,7 +548,7 @@ class TestImagesMeanByRegions(PySparkTestCase):
     def test_meanWithMultipleRegionIndices(self):
         indices = [[(0, 0), (0, 1)], [(0, 1), (1, 0)]]  # two regions with two indices each
         regionMeanImages = self.images.meanByRegions(indices)
-        self.__checkAttrPropagation(regionMeanImages)
+        self.__checkAttrPropagation(regionMeanImages, (1, 2))
         collected = regionMeanImages.collect()
         assert_equals(2, len(collected))
         assert_equals((1, 2), collected[0][1].shape)

--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -531,6 +531,36 @@ class TestImagesMeanByRegions(PySparkTestCase):
         assert_equals(15, collected[1][1].flat[0])
         assert_equals(16, collected[1][1].flat[1])
 
+    def test_meanWithSingleRegionIndices(self):
+        indices = [[(0, 0), (0, 1)]]  # one region with two indices
+        regionMeanImages = self.images.meanByRegions(indices)
+        self.__checkAttrPropagation(regionMeanImages)
+        collected = regionMeanImages.collect()
+        assert_equals(2, len(collected))
+        assert_equals((1, 1), collected[0][1].shape)
+        # check keys
+        assert_equals(0, collected[0][0])
+        assert_equals(1, collected[1][0])
+        # check values
+        assert_equals(4, collected[0][1][0])
+        assert_equals(14, collected[1][1][0])
+
+    def test_meanWithMultipleRegionIndices(self):
+        indices = [[(0, 0), (0, 1)], [(0, 1), (1, 0)]]  # two regions with two indices each
+        regionMeanImages = self.images.meanByRegions(indices)
+        self.__checkAttrPropagation(regionMeanImages)
+        collected = regionMeanImages.collect()
+        assert_equals(2, len(collected))
+        assert_equals((1, 2), collected[0][1].shape)
+        # check keys
+        assert_equals(0, collected[0][0])
+        assert_equals(1, collected[1][0])
+        # check values
+        assert_equals(4, collected[0][1].flat[0])
+        assert_equals(5, collected[0][1].flat[1])
+        assert_equals(14, collected[1][1].flat[0])
+        assert_equals(15, collected[1][1].flat[1])
+
 
 class TestImagesUsingOutputDir(PySparkTestCaseWithOutputDir):
 

--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -561,6 +561,19 @@ class TestImagesMeanByRegions(PySparkTestCase):
         assert_equals(14, collected[1][1].flat[0])
         assert_equals(15, collected[1][1].flat[1])
 
+    def test_badIndexesThrowErrors(self):
+        indices = [[(0, 0), (-1, 0)]]  # index too small (-1)
+        assert_raises(ValueError, self.images.meanByRegions, indices)
+
+        indices = [[(0, 0), (2, 0)]]  # index too large (2)
+        assert_raises(ValueError, self.images.meanByRegions, indices)
+
+        indices = [[(0, 0), (0,)]]  # too few indices
+        assert_raises(ValueError, self.images.meanByRegions, indices)
+
+        indices = [[(0, 0), (0, 1, 0)]]  # too many indices
+        assert_raises(ValueError, self.images.meanByRegions, indices)
+
 
 class TestImagesUsingOutputDir(PySparkTestCaseWithOutputDir):
 

--- a/python/test/test_series.py
+++ b/python/test/test_series.py
@@ -217,63 +217,6 @@ class TestSeriesMethods(PySparkTestCase):
         assert(allclose(values[0, :], array([1.5, 2., 3.5])))
         assert_equals(data.dtype, values[0, :].dtype)
 
-    def __setup_meanByRegion(self):
-        dataLocal = [
-            ((0, 0), array([1.0, 2.0, 3.0])),
-            ((0, 1), array([2.0, 2.0, 4.0])),
-            ((1, 0), array([4.0, 2.0, 1.0])),
-            ((1, 1), array([3.0, 1.0, 1.0]))
-        ]
-        series = Series(self.sc.parallelize(dataLocal))
-        itemIdxs = [1, 2]  # data keys for items 1 and 2 (0-based)
-        keys = [dataLocal[idx][0] for idx in itemIdxs]
-
-        expectedKeys = tuple(vstack(keys).mean(axis=0).astype('int16'))
-        expected = vstack([dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
-        return series, keys, expectedKeys, expected
-
-    def test_meanOfRegion(self):
-        series, keys, expectedKeys, expected = self.__setup_meanByRegion()
-
-        actual = series.meanOfRegion(keys)
-        assert_equals(2, len(actual))
-        assert_equals(expectedKeys, actual[0])
-        assert_true(array_equal(expected, actual[1]))
-
-    def test_meanByRegions_singleRegion(self):
-        series, keys, expectedKeys, expected = self.__setup_meanByRegion()
-
-        actualSeries = series.meanByRegion([keys])
-        actual = actualSeries.collect()
-        assert_equals(1, len(actual))
-        assert_equals(expectedKeys, actual[0][0])
-        assert_true(array_equal(expected, actual[0][1]))
-
-    def test_meanByRegions_twoRegions(self):
-        dataLocal = [
-            ((0, 0), array([1.0, 2.0, 3.0])),
-            ((0, 1), array([2.0, 2.0, 4.0])),
-            ((1, 0), array([4.0, 2.0, 1.0])),
-            ((1, 1), array([3.0, 1.0, 1.0]))
-        ]
-        series = Series(self.sc.parallelize(dataLocal))
-        nestedKeys, expectedKeys, expected = [], [], []
-        expectedKeys = []
-        for itemIdxs in [(0, 1), (1, 2)]:
-            keys = [dataLocal[idx][0] for idx in itemIdxs]
-            nestedKeys.append(keys)
-            avgKeys = tuple(vstack(keys).mean(axis=0).astype('int16'))
-            expectedKeys.append(avgKeys)
-            avgVals = vstack([dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
-            expected.append(avgVals)
-
-        actualSeries = series.meanByRegion(nestedKeys)
-        actual = actualSeries.collect()
-        assert_equals(2, len(actual))
-        for regionIdx in xrange(2):
-            assert_equals(expectedKeys[regionIdx], actual[regionIdx][0])
-            assert_true(array_equal(expected[regionIdx], actual[regionIdx][1]))
-
     def test_maxProject(self):
         from thunder.rdds.fileio.seriesloader import SeriesLoader
         ary = arange(8, dtype=dtypeFunc('int16')).reshape((2, 4))
@@ -287,3 +230,91 @@ class TestSeriesMethods(PySparkTestCase):
 
         assert_true(array_equal(amax(ary.T, 0), project0))
         assert_true(array_equal(amax(ary.T, 1), project1))
+
+
+class TestSeriesRegionMeanMethods(PySparkTestCase):
+    def setUp(self):
+        super(TestSeriesRegionMeanMethods, self).setUp()
+        self.dataLocal = [
+            ((0, 0), array([1.0, 2.0, 3.0])),
+            ((0, 1), array([2.0, 2.0, 4.0])),
+            ((1, 0), array([4.0, 2.0, 1.0])),
+            ((1, 1), array([3.0, 1.0, 1.0]))
+        ]
+        self.series = Series(self.sc.parallelize(self.dataLocal))
+
+    def __setup_meanByRegion(self, useMask=False):
+        itemIdxs = [1, 2]  # data keys for items 1 and 2 (0-based)
+        keys = [self.dataLocal[idx][0] for idx in itemIdxs]
+
+        expectedKeys = tuple(vstack(keys).mean(axis=0).astype('int16'))
+        expected = vstack([self.dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
+        if useMask:
+            keys = array([[0, 1], [1, 0]], dtype='uint8')
+        return keys, expectedKeys, expected
+
+    @staticmethod
+    def __checkAsserts(expectedLen, expectedKeys, expected, actual):
+        assert_equals(expectedLen, len(actual))
+        assert_equals(expectedKeys, actual[0])
+        assert_true(array_equal(expected, actual[1]))
+
+    @staticmethod
+    def __checkNestedAsserts(expectedLen, expectedKeys, expected, actual):
+        assert_equals(expectedLen, len(actual))
+        for i in xrange(expectedLen):
+            assert_equals(expectedKeys[i], actual[i][0])
+            assert_true(array_equal(expected[i], actual[i][1]))
+
+    def __run_tst_meanOfRegion(self, useMask):
+        keys, expectedKeys, expected = self.__setup_meanByRegion(useMask)
+        actual = self.series.meanOfRegion(keys)
+        TestSeriesRegionMeanMethods.__checkAsserts(2, expectedKeys, expected, actual)
+
+    def test_meanOfRegion(self):
+        self.__run_tst_meanOfRegion(False)
+
+    def test_meanOfRegionWithMask(self):
+        self.__run_tst_meanOfRegion(True)
+
+    def test_meanByRegions_singleRegion(self):
+        keys, expectedKeys, expected = self.__setup_meanByRegion()
+
+        actualSeries = self.series.meanByRegion([keys])
+        actual = actualSeries.collect()
+        TestSeriesRegionMeanMethods.__checkNestedAsserts(1, [expectedKeys], [expected], actual)
+
+    def test_meanByRegions_singleRegionWithMask(self):
+        mask, expectedKeys, expected = self.__setup_meanByRegion(True)
+
+        actualSeries = self.series.meanByRegion(mask)
+        actual = actualSeries.collect()
+        TestSeriesRegionMeanMethods.__checkNestedAsserts(1, [expectedKeys], [expected], actual)
+
+    def test_meanByRegions_twoRegions(self):
+        nestedKeys, expectedKeys, expected = [], [], []
+        for itemIdxs in [(0, 1), (1, 2)]:
+            keys = [self.dataLocal[idx][0] for idx in itemIdxs]
+            nestedKeys.append(keys)
+            avgKeys = tuple(vstack(keys).mean(axis=0).astype('int16'))
+            expectedKeys.append(avgKeys)
+            avgVals = vstack([self.dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
+            expected.append(avgVals)
+
+        actualSeries = self.series.meanByRegion(nestedKeys)
+        actual = actualSeries.collect()
+        TestSeriesRegionMeanMethods.__checkNestedAsserts(2, expectedKeys, expected, actual)
+
+    def test_meanByRegions_twoRegionsWithMask(self):
+        expectedKeys, expected = [], []
+        mask = array([[1, 1], [2, 0]], dtype='uint8')
+        for itemIdxs in [(0, 1), (2, )]:
+            keys = [self.dataLocal[idx][0] for idx in itemIdxs]
+            avgKeys = tuple(vstack(keys).mean(axis=0).astype('int16'))
+            expectedKeys.append(avgKeys)
+            avgVals = vstack([self.dataLocal[idx][1] for idx in itemIdxs]).mean(axis=0)
+            expected.append(avgVals)
+
+        actualSeries = self.series.meanByRegion(mask)
+        actual = actualSeries.collect()
+        TestSeriesRegionMeanMethods.__checkNestedAsserts(2, expectedKeys, expected, actual)

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -84,8 +84,9 @@ class Data(object):
         if isinstance(other, Data):
             for name in self._metadata:
                 if name not in noPropagate:
-                    if (getattr(other, name, None) is not None) and (getattr(self, name, None) is None):
-                        object.__setattr__(self, name, getattr(other, name, None))
+                    otherAttr = getattr(other, name, None)
+                    if (otherAttr is not None) and (getattr(self, name, None) is None):
+                        object.__setattr__(self, name, otherAttr)
         return self
 
     @property

--- a/python/thunder/rdds/images.py
+++ b/python/thunder/rdds/images.py
@@ -417,8 +417,8 @@ class Images(Data):
         return self._constructor(newrdd, dims=newdims).__finalize__(self)
 
     def meanByRegions(self, selection):
-        """Collapses images into one or more spatial mean values as specified by the passed mask array or sequence of
-        indicies.
+        """Reduces images to one or more spatially averaged values using the given selection, which can be
+        either a mask array or sequence of indicies.
 
         A passed mask must be a numpy ndarray of the same shape as the individual arrays in this
         Images object. If the mask array is of integer or unsigned integer type, one mean value will

--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -740,8 +740,8 @@ class Series(Data):
         def toRegionIdx(kvIter):
             regionLookup_ = bcRegionLookup.value
             for k, val in kvIter:
-                for regionIdx in regionLookup_.get(k, []):
-                    yield regionIdx, (k, val)
+                for regionIdx_ in regionLookup_.get(k, []):
+                    yield regionIdx_, (k, val)
 
         combinedData = self.rdd.mapPartitions(toRegionIdx) \
             .combineByKey(_MeanCombiner.createMeanTuple,
@@ -762,7 +762,8 @@ class Series(Data):
                     # the final map. This contrasts with the current implementation of meanOfRegion, where
                     # we've already finished the calculation by the time we can do the error checking, and so
                     # there we just print a warning but return the values anyway.
-                    msg = "%d records were expected in region %d, but only %d were found" % (expectedNRecords, regionIdx, n)
+                    msg = "%d records were expected in region %d, but only %d were found" % \
+                          (expectedNRecords, regionIdx, n)
                     if mismatchBehavior == "error":
                         raise ValueError(msg)
                     else:


### PR DESCRIPTION
This PR expands on the functionality introduced in PR #95, adding support for specifying regions via an array mask on the Series mean of/by region(s) methods, and adding a `meanByRegions` method on Images. 

The new images method currently returns Images where each record value is a 1 x N array, with N being the number of regions specified. This can then be converted into time series values via the usual `images.toSeries().collect()` dance, which should run very quickly since after the aggregation into regions there should be almost no data left. :) The Images meanByRegions method supports region specification either by a mask array or by passing a sequence of sequences of indices, as in the equivalent Series method.