### PR TITLE
(WIP) Lucas-Kanade registration

### DIFF
--- a/thunder/registration/__init__.py
+++ b/thunder/registration/__init__.py
@@ -1,1 +1,2 @@
 from thunder.registration.methods.crosscorr import CrossCorr, PlanarCrossCorr
+from thunder.registration.methods.lucaskanade import LucasKanade

--- a/thunder/registration/methods/lucaskanade.py
+++ b/thunder/registration/methods/lucaskanade.py
@@ -1,0 +1,100 @@
+""" Registration methods based on Lucas-Kanade registration"""
+#XXX:
+from matplotlib.pyplot import *
+
+from numpy import array, ndarray, inf, zeros
+
+from thunder.rdds.images import Images
+from thunder.imgprocessing.registration import RegistrationMethod
+from thunder.imgprocessing.transformation import GridTransformer, TRANSFORMATION_TYPES
+from thunder.imgprocessing.regmethods.utils import volumesToMatrix, imageJacobian, solveLinearized, computeReferenceMean, checkReference
+
+
+class LucasKanadeRegistration(RegistrationMethod):
+    """Lucas-Kanade registration method.
+
+    Lucas-Kanade (LK) is an iterative algorithm for aligning an image to a reference. It aims to minimize the squared
+    error between the transformed image and the reference. As the relationship between transformation parameters and
+    transformed pixels is nonlinear, we have to perform a series of linearizations similar to Levenberg-Marquardt.
+    At each iteration, we compute the Jacobian of the output image with respect to the input parameters, and solve a
+    least squares problem to identify a change in parameters. We update the parameters and repeat.
+
+    To increase robustness, we extend the traditional LK algorithm to use a set of reference images.
+    We minimize the squared error of the difference of the transformed image and a learned weighting of the references.
+    """
+
+    def __init__(self, transformationType='Translation', border=0, tol=1e-5, maxIter=10, robust=False):
+        """
+        Parameters
+        ----------
+        transformationType : one of 'Translation', 'Euclidean', optional, default = 'Translation'
+            type of transformation to use
+        border : int or tuple, optional, default = 0
+            Border to be zeroed out after transformations. For most datasets, it is
+            critical that this value be larger than the maximum translation to get
+            good results and avoid boundary artifacts.
+        maxIter : int, optional, default = 10
+            maximum number of iterations
+        tol : float, optional, default = 1e-5
+            stopping criterion on the L2 norm of the change in parameters
+        robust : bool, optional, default = False
+            solve a least absolute deviation problem instead of least squares
+        """
+        self.transformationType = transformationType
+        self.border = border
+        self.maxIter = maxIter
+        self.tol = tol
+        self.robust = robust
+
+    def prepare(self, images, startidx=None, stopidx=None):
+        """
+        Prepare Lucas-Kanade registration by computing or specifying a reference image.
+
+        Parameters
+        ----------
+        images : ndarray or Images object
+            Images to compute reference from, or a single image to set as reference
+
+        See computeReferenceMean.
+        """
+        if isinstance(images, Images):
+            self.reference = computeReferenceMean(images, startidx, stopidx)
+        elif isinstance(images, ndarray):
+            self.reference = images
+        else:
+            raise Exception('Must provide either an Images object or a reference')
+        # Convert references to matrix to speed up solving linearized system
+        self.referenceMat = volumesToMatrix(self.reference)
+        return self
+
+    def isPrepared(self, images):
+        """
+        Check if Lucas-Kanade is prepared by checking the dimensions of the reference.
+
+        See checkReference.
+        """
+
+        if not hasattr(self, 'reference'):
+            raise Exception('Reference not defined')
+        else:
+            checkReference(self.reference, images)
+
+    def getTransform(self, vol):
+        from numpy.linalg import norm
+        # Create initial transformation
+        tfm = TRANSFORMATION_TYPES[self.transformationType](shift=zeros(vol.ndim))
+        iter = 0
+        normDelta = inf
+        params = []
+        while iter < self.maxIter and normDelta > self.tol:
+            iter += 1
+            volTfm, jacobian = tfm.jacobian(vol, border=self.border)
+            #XXX
+            from matplotlib.pyplot import *
+            plot(np.array(params));show()
+            #imshow(jacobian[0]);title(np.linalg.norm(jacobian[0])); show()
+            deltaTransformParams, coeff = solveLinearized(volumesToMatrix(volTfm), volumesToMatrix(jacobian), self.referenceMat, self.robust)
+            tfm.updateParams(deltaTransformParams)
+            normDelta = norm(deltaTransformParams)
+            params.append(tfm.getParams())
+        return tfm

--- a/thunder/registration/methods/lucaskanade.py
+++ b/thunder/registration/methods/lucaskanade.py
@@ -5,12 +5,12 @@ from matplotlib.pyplot import *
 from numpy import array, ndarray, inf, zeros
 
 from thunder.rdds.images import Images
-from thunder.imgprocessing.registration import RegistrationMethod
-from thunder.imgprocessing.transformation import GridTransformer, TRANSFORMATION_TYPES
-from thunder.imgprocessing.regmethods.utils import volumesToMatrix, imageJacobian, solveLinearized, computeReferenceMean, checkReference
+from thunder.registration.registration import RegistrationMethod
+from thunder.registration.transformation import GridTransformer, TRANSFORMATION_TYPES
+from thunder.registration.methods.utils import volumesToMatrix, imageJacobian, solveLinearized, computeReferenceMean, checkReference
 
 
-class LucasKanadeRegistration(RegistrationMethod):
+class LucasKanade(RegistrationMethod):
     """Lucas-Kanade registration method.
 
     Lucas-Kanade (LK) is an iterative algorithm for aligning an image to a reference. It aims to minimize the squared
@@ -90,9 +90,6 @@ class LucasKanadeRegistration(RegistrationMethod):
             iter += 1
             volTfm, jacobian = tfm.jacobian(vol, border=self.border)
             #XXX
-            from matplotlib.pyplot import *
-            plot(np.array(params));show()
-            #imshow(jacobian[0]);title(np.linalg.norm(jacobian[0])); show()
             deltaTransformParams, coeff = solveLinearized(volumesToMatrix(volTfm), volumesToMatrix(jacobian), self.referenceMat, self.robust)
             tfm.updateParams(deltaTransformParams)
             normDelta = norm(deltaTransformParams)

--- a/thunder/registration/methods/utils.py
+++ b/thunder/registration/methods/utils.py
@@ -123,3 +123,175 @@ def computeDisplacement(arry1, arry2):
     adjusted = [int(d - n) if d > n // 2 else int(d) for (d, n) in pairs]
 
     return adjusted
+
+def zeroBorder(vol, border=1, cval=0.0):
+    """Zero-out boundary voxels of a volume.
+
+    Parameters
+    ----------
+        vol: 3d volume
+        border: scalar or tuple containing borders for each dimension
+        cval: constant value to replace boundary voxels with, default is 0.0
+    """
+    import numpy as np # sorry
+    vol = vol.copy() # create new copy so we don't overwrite vol
+    dims = np.array(vol.shape)
+    if np.size(border) == 1:
+        border = border * np.ones(vol.ndim, dtype=int)
+    border = np.array(border, dtype=int)
+    # Don't apply border to singleton dimensions.
+    border[dims == 1] = 0
+    assert len(border) == vol.ndim
+    if np.any(dims - border <= 0):
+        raise ValueError('Border %s exceeds volume shape %s.' %
+                (str(border), str(dims)) )
+    for dim, bval in enumerate(border):
+        if bval > 0:
+            slices = [slice(bval) if d == dim else slice(None) for d in xrange(vol.ndim)]
+            vol[slices] = cval
+            slices[dim] = slice(-bval, None)
+            vol[slices] = cval
+    return vol
+
+
+def solveLinearized(vec, jacobian, reference, robust=False):
+    """Solve linearized registration problem for change in transformation parameters and weighting on reference basis.
+
+    Parameters
+    ----------
+    vec : array, shape (nvoxels,)
+        vectorized volume
+    jacobian: array, shape (nvoxels, nparams)
+        jacobian for each transformation parameter
+    reference: array, shape (nvoxels, nbasis)
+        array of vectorized reference volumes
+    robust: bool, optional, default = False
+        solve a least absolute deviation problem instead of least squares
+
+    Returns
+    -------
+    deltaTransforms : array, shape (nparams,)
+        optimal change in transformation parameters
+    coeff : array, shape (nbasis,)
+        optimal weighting of reference volumes
+    """
+    from numpy import column_stack
+    A = column_stack((jacobian, reference))
+    if robust:
+        from statsmodels.regression.quantile_regression import QuantReg
+        quantile = 0.5
+        model = QuantReg(vec, A).fit(q=quantile)
+        params = model.params
+    else:
+        from numpy.linalg import lstsq
+        model = lstsq(A, vec)
+        params = model[0]
+    from numpy import split
+    deltaTransform, coeff = split(params, [jacobian.shape[1]])
+    return deltaTransform, coeff
+
+
+def volToVec(vol):
+    """
+    Convert volume to vector.
+
+    Parameters
+    ----------
+    vol : array
+        volume
+
+    Returns
+    -------
+    vectorized volume
+    """
+    return vol.ravel()
+
+
+def vecToVol(vec, dims):
+    """
+    Convert vector to volume.
+
+    Parameters
+    ----------
+    vec : array, shape (nvoxels,)
+        vectorized volume
+    dims : tuple, optional
+        shape of volume, must be set to reshape vectors into volumes
+
+    Returns
+    -------
+    volume if input is a vector, and vector if input is a volume
+    """
+    assert vec.size == prod(dims)
+    return vec.reshape(dims)
+
+
+def volumesToMatrix(vols):
+    """Convert list of volumes to a matrix.
+
+    Parameters
+    ----------
+    vols : list of arrays
+
+    Returns
+    -------
+    array with size nvoxels by number of volumes
+    """
+    from numpy import column_stack
+    if not isinstance(vols, list):
+        return volToVec(vols)
+    else:
+        return column_stack(map(volToVec, vols)).squeeze()
+
+
+def imageGradients(im, sigma=None):
+    """Compute gradients of volume in each dimension using a Sobel filter.
+
+    Parameters
+    ----------
+    im : ndarray
+        single volume
+    sigma : float or tuple, optional, default = None
+        smoothing amount to apply to volume before computing gradients
+    """
+    from scipy.ndimage.filters import gaussian_filter, sobel
+    if sigma is not None:
+        im = gaussian_filter(im, sigma)
+    grads = [sobel(im, axis=dim, mode='constant') / 8.0 for dim in xrange(im.ndim)]
+    return grads
+
+
+def imageJacobian(vol, tfm, grid=None, sigma=None, normalize=True, border=1, order=1):
+    """Compute Jacobian of volume w.r.t. transformation parameters
+
+    Args:
+        vol: volume
+        tfm: Transform object
+        sigma: smoothing bandwidth for gradients (None for no smoothing)
+        normalize: Whether to normalize images before aligning.
+        border: Number or tuple of border sizes to zero after transforming.
+        order: interpolation order used by map_coordinates
+    Returns:
+        tvol : array
+            transformed volume
+        jacobianVols : list of arrays
+            list of volume Jacobians, one for each parameter of the transformation
+    """
+    from numpy.linalg import norm
+    if grid is None:
+        from thunder.imgprocessing.transformation import GridTransformer
+        grid = GridTransformer(vol.shape)
+    grads = imageGradients(vol, sigma)
+    tvol = zeroBorder(tfm.apply(vol, grid, order=order))
+    normVol = norm(tvol.ravel())
+    if normVol == 0.0:
+        raise ValueError('Transform yields volume of zeroes.')
+    grads = [zeroBorder(tfm.apply(grad, grid, order=order)) for grad in grads]
+    if normalize:
+        if normVol == 0.0:
+            raise ValueError('Transform yields volume of zeroes.')
+        # Update gradients to reflect normalization
+        grads = [grad / normVol - (grad * tvol).sum() / (normVol**3) * tvol for grad in grads]
+        tvol /= normVol
+    jacobianVols = tfm.jacobian(grads, grid.homo_points)
+    return tvol, jacobianVols

--- a/thunder/registration/methods/utils.py
+++ b/thunder/registration/methods/utils.py
@@ -279,7 +279,7 @@ def imageJacobian(vol, tfm, grid=None, sigma=None, normalize=True, border=1, ord
     """
     from numpy.linalg import norm
     if grid is None:
-        from thunder.imgprocessing.transformation import GridTransformer
+        from thunder.registration.transformation import GridTransformer
         grid = GridTransformer(vol.shape)
     grads = imageGradients(vol, sigma)
     tvol = zeroBorder(tfm.apply(vol, grid, order=order))

--- a/thunder/registration/registration.py
+++ b/thunder/registration/registration.py
@@ -20,10 +20,12 @@ class Registration(object):
     def __new__(cls, method, **kwargs):
 
         from thunder.registration.methods.crosscorr import CrossCorr, PlanarCrossCorr
+        from thunder.registration.methods.lucaskanade import LucasKanade
 
         REGMETHODS = {
             'crosscorr': CrossCorr,
-            'planarcrosscorr': PlanarCrossCorr
+            'planarcrosscorr': PlanarCrossCorr,
+            'lucaskanade': LucasKanade,
         }
 
         checkParams(method, REGMETHODS.keys())

--- a/thunder/registration/transformation.py
+++ b/thunder/registration/transformation.py
@@ -9,6 +9,290 @@ class Transformation(object):
     def apply(self, im):
         raise NotImplementedError
 
+class GridMixin(object):
+    grid = None
+
+    @classmethod
+    def getGrid(cls, dims):
+        """
+        Check and (if needed) initialize a grid with the appropriate dimensions.
+
+        Parameters
+        ----------
+        dims : tuple
+            shape of volume
+        """
+        if cls.grid is None or cls.grid[0].shape != dims:
+            # Create an array containing the homogenous coordinate for each voxel
+            cls.grid = np.vstack((np.array(np.meshgrid(*[np.arange(d) for d in dims], indexing='ij')),
+                                  np.ones(dims)[np.newaxis, :, :]))
+        return cls.grid
+
+    def getCoords(self, grid):
+        """
+        Get the coordinates where the input volume is evaluated.
+
+        Returns
+        -------
+        array with size ndims by nvoxels specifying the coordinates for each voxel.
+        """
+        raise NotImplementedError
+
+    def apply(self, vol, **kwargs):
+        from scipy.ndimage import map_coordinates
+        grid = self.getGrid(vol.shape)
+        coords = self.getCoords(grid)
+        tvol = map_coordinates(vol, coords, cval=0.0, **kwargs)
+        return tvol
+
+class DifferentiableTransformation(Transformation):
+    """
+    Differentiable transformations must have methods to compute the Jacobian and update parameters. These are used by
+    iterative alignment techniques like Lucas-Kanade and RASL.
+    """
+
+    def _jacobianCoords(self, vol, sigma=None, normalize=True, border=1):
+        """Compute Jacobian of volume with respect to the coordinates.
+
+        Args:
+            vol: volume
+            tfm: Transform object
+            sigma: smoothing bandwidth for gradients (None for no smoothing)
+            normalize: Whether to normalize images before aligning.
+            border: Number or tuple of border sizes to zero after transforming.
+        Returns:
+            tvol : array
+                transformed volume
+            grads : list of arrays
+                list of volume Jacobians with respect to coordinates, one for each dimension
+        """
+        from numpy.linalg import norm
+        from thunder.imgprocessing.regmethods.utils import imageGradients, zeroBorder
+
+        grads = imageGradients(vol, sigma)
+        tvol = zeroBorder(self.apply(vol), border)
+        normVol = norm(tvol.ravel())
+        if normVol == 0.0:
+            raise ValueError('Transform yields volume of zeroes.')
+        grads = [zeroBorder(self.apply(grad), border) for grad in grads]
+        if normalize:
+            if normVol == 0.0:
+                raise ValueError('Transform yields volume of zeroes.')
+            # Update gradients to reflect normalization
+            grads = [grad / normVol - (grad * tvol).sum() / (normVol**3) * tvol for grad in grads]
+            tvol /= normVol
+        return tvol, grads
+
+    def jacobian(self, vol, **kwargs):
+        """
+        Compute gradient of transformation output with respect to parameters.
+
+        Parameters
+        ----------
+        vol : array
+            volume
+
+        Returns
+        -------
+        ordered list of arrays containing the Jacobian for each parameter
+        """
+        raise NotImplementedError
+
+    def getParams(self):
+        """
+        Get the parameters of this transformation.
+
+        Returns
+        -------
+        array with shape (nparams,)
+        """
+        raise NotImplementedError
+
+    def setParams(self, params):
+        """
+        Set each parameter in the transformation.
+
+        Parameters
+        ----------
+        params : array, shape (nparams,)
+            new values of parameters. The ordering here must match
+            the ordering of the parameters returned by jacobian.
+        """
+        raise NotImplementedError
+
+    def updateParams(self, deltaParams):
+        """
+        Update each parameter in the transformation.
+
+        Parameters
+        ----------
+        deltaParams : array, shape (nparams,)
+            ordered changes in parameters to be applied. The ordering here must match
+            the ordering of the parameters returned by jacobian.
+        """
+        self.setParams(self.getParams() + deltaParams)
+
+
+class TranslationTransformation(DifferentiableTransformation):
+    def __init__(self, shift):
+        """Translation in 3d.
+
+        Parameters
+        ----------
+            shift: 3d vector of translations (x, y, z)
+
+        """
+        self.shift = shift
+
+    def jacobian(self, vol, **kwargs):
+        return self._jacobianCoords(vol, **kwargs)
+
+    def getParams(self):
+        return np.asarray(self.shift)
+
+    def setParams(self, shift):
+        assert len(shift) == len(self.shift)
+        self.shift = shift
+
+    def apply(self, vol):
+        from scipy.ndimage.interpolation import shift
+        return shift(vol, self.shift, mode='nearest')
+
+
+class ProjectiveTransformation(GridMixin, DifferentiableTransformation):
+    """
+    Affine transformations are differentiable and can be represented as a matrix."""
+
+    def __init__(self, center=None):
+        self.center = center
+
+    def asMatrix(self):
+        raise NotImplementedError
+
+    def getCoords(self, grid):
+        d = grid.shape[0] - 1  # number of dimensions
+        dims = grid.shape[1:]
+        if self.center is None:
+            self.center = (np.array(dims) - 1) / 2.0
+
+        A = self.asMatrix()
+
+        # Center grid so that we apply rotations w.r.t. given center
+        if self.center is not None:
+            grid = grid - np.r_[self.center, 0][:, np.newaxis, np.newaxis]
+
+        # Apply transformation
+        grid = np.tensordot(A.T, grid, axes=(0,0))
+
+        # Move back to voxel reference frame
+        if self.center is not None:
+            grid = grid + np.r_[self.center, 0][:, np.newaxis, np.newaxis]
+
+        return grid[:-1]  # throw out last homogeneous coordinate
+
+class EuclideanTransformation(ProjectiveTransformation):
+    def __init__(self, shift, rotation=None, zTranslation=False, zRotation=False, center=None):
+        """Translation and rotation in 3d.
+
+        Parameters
+        ----------
+        shift : list or array
+            spatial shifts for each dimension
+        rotation : float, list, or array
+            rotation in x-y if scalar. rotation in x-y plane, x-z plane, y-z plane if list
+            or array and dataset is in 3d.
+        zTranslation : bool, optional, default = False
+            whether to allow translation in z
+        zRotation : bool, optional, default = False
+            whether to allow rotation in z
+        center : list or array, optional, default = None
+            Set center coordinates that define the point around which the volume is rotated.
+            Coordinates should be in terms of zero-indexed pixels. For example if the volume was 5x5x3,
+            the default center of rotation would be at the center of the volume: (2, 2, 1).
+        """
+        self.shift = np.atleast_1d(shift)
+        self.ndim = len(self.shift)
+        if rotation is None:
+            if self.ndim == 2 or not zRotation:
+                rotation = 0.0
+            else:
+                rotation = np.zeros(3)
+        self.rotation = np.atleast_1d(rotation)
+        self.zRotation = zRotation
+        self.zTranslation = zTranslation
+        self.center = center
+
+    def getParams(self):
+        return np.r_[self.shift, self.rotation]
+
+    def updateParams(self, deltaParams):
+        if self.ndim == 2:
+            self.shift += deltaParams[:2]
+            self.rotation += deltaParams[2]
+        else:
+            self.shift += deltaParams[:3]
+            self.rotation += deltaParams[3:]
+
+    def jacobian(self, vol, **kwargs):
+
+        tvol, imageGradients = self._jacobianCoords(vol, **kwargs)
+        imageGrid = self.grid
+        ndim = len(self.shift)
+
+        stheta = np.sin(self.rotation[0])
+        ctheta = np.cos(self.rotation[0])
+
+        if ndim == 2 or not self.zRotation:
+            dtheta = imageGradients[0] * (-imageGrid[0] * stheta  + imageGrid[1] * -ctheta)
+            dtheta += imageGradients[1] * ( imageGrid[0] * ctheta  + imageGrid[1] * -stheta)
+            dangles = [dtheta]
+        else:
+            sphi = np.sin(self.rotation[1])
+            cphi = np.cos(self.rotation[1])
+            spsi = np.sin(self.rotation[2])
+            cpsi = np.cos(self.rotation[2])
+            dtheta = imageGradients[0] * (
+               -imageGrid[0] * cphi * stheta +
+                imageGrid[1] * (-ctheta * cpsi - stheta * sphi * spsi) +
+                imageGrid[2] * (-cpsi * stheta * sphi + ctheta * spsi))
+            dtheta +=  imageGradients[1] * (
+                imageGrid[0] * ctheta * cphi +
+                imageGrid[1] * (-cpsi * stheta + ctheta * sphi * spsi) +
+                imageGrid[2] * (ctheta * cpsi * sphi + stheta * spsi))
+            dphi =  imageGradients[0] * (
+                imageGrid[2] * ctheta * cphi * cpsi -
+                imageGrid[0] * ctheta * sphi +
+                imageGrid[1] * ctheta * cphi * spsi)
+            dphi += imageGradients[1] * (
+                imageGrid[2] * cphi * cpsi * stheta -
+                imageGrid[0] * stheta * sphi +
+                imageGrid[1] * cphi * stheta * spsi)
+            dphi += imageGradients[2] * (
+               -imageGrid[0] * cphi -
+                imageGrid[2] * cpsi * sphi -
+                imageGrid[1] * sphi * spsi)
+            dpsi = imageGradients[0] * (
+                imageGrid[1] * (ctheta * cpsi * sphi + stheta * spsi) +
+                imageGrid[2] * (cpsi * stheta - ctheta * sphi * spsi) )
+            dpsi += imageGradients[1] * (
+                imageGrid[1] * (cpsi * stheta * sphi - ctheta * spsi) +
+                imageGrid[2] * (-ctheta * cpsi - stheta * sphi * spsi))
+            dpsi += imageGradients[2] * (imageGrid[1] * cphi * cpsi - imageGrid[2] * cphi * spsi)
+            dangles = [dtheta, dphi, dpsi]
+
+        # Zero-out Jacobian corresponding to z translation
+        if ndim == 3 and not self.zTranslation:
+            imageGradients[2][:] = 0.0
+        return tvol, imageGradients + dangles
+
+    def asMatrix(self):
+        return transformationMatrix(self.shift,  self.rotation)
+
+    def __repr__(self):
+        return "EuclideanTransformation(shift=%s, rotation=%s)" % (repr(self.shift), repr(self.rotation))
+
+
+
 
 class Displacement(Transformation, Serializable):
     """
@@ -92,3 +376,98 @@ class PlanarDisplacement(Transformation, Serializable):
 
     def __repr__(self):
         return "PlanarDisplacement(delta=%s)" % repr(self.delta)
+
+
+class GridTransformer(object):
+    def __init__(self, dims, center=None):
+        """Class to represent and transform a fixed grid of points over indices into a volume.
+
+        Args:
+            dims: vol_shape[::-1]
+            center: center location of grid, defaults to the centroid.
+                    Affine transfroms will be applied to the center-subtracted grid,
+                    so the center corresponds to the point of rotation.
+        """
+        self.dims = np.array(dims)
+        self.ndim = len(dims)
+        if center is None:
+            center = (self.dims - 1) / 2.0
+        self.center = center
+        self.homo_points = np.ones((self.ndim + 1,) + dims)
+        self.homo_points[:-1, ...] = np.array(np.mgrid[[slice(p) for p in self.dims]])
+        self.raw_points = self.homo_points.copy()
+        self.world_to_index_tfm = transformationMatrix(self.center, np.zeros(self.ndim))
+        self.index_to_world_tfm = transformationMatrix(-self.center, np.zeros(self.ndim))
+        self.homo_points = self.transform_grid_world(self.index_to_world_tfm)
+        self.index_points = self.transform_grid_world(self.world_to_index_tfm)
+
+    def transform_grid_world(self, A):
+        """Get the grid of points in world space after applying the given affine transform."""
+        return np.tensordot(A.T, self.homo_points, axes=(0, 0))
+
+    def transform_grid(self, A):
+        """Get the grid of points in index space after applying the given affine transform
+           in world space.
+
+        Args:
+            A: 4x4 Affine transformation matrix
+        Returns:
+            y: 4 x dims[0] x dims[1] x dims[2] matrix containing the grid
+        """
+        return self.transform_grid_world(np.dot(self.world_to_index_tfm, A))
+
+    def transform_vol(self, vol, A, **kwargs):
+        from scipy.ndimage import map_coordinates
+        new_grid = self.transform_grid(A)[:-1]
+        transformed_vol = map_coordinates(vol, new_grid, cval=0.0, **kwargs)
+        return transformed_vol
+
+
+def transformationMatrix(shift, rot=None):
+    """Create an affine transformation matrix
+
+    Parameters
+    ----------
+    shift : array, shape (ndim,)
+        translations along each dimension
+    rot : scalar or array with shape (ndim, )
+
+    Returns
+    -------
+    A : array, shape (ndims + 1, ndims + 1)
+        transformation matrix that shifts and rotates a set of points in homogeneous coordinates
+    """
+
+    ndim = len(shift)
+    if rot is None:
+        rot = np.zeros(ndim)
+    else:
+        rot = np.atleast_1d(rot)
+    c = np.cos(rot)
+    s = np.sin(rot)
+    trans = np.eye(ndim + 1)
+    trans[:-1, -1] = shift
+    xrot = np.array(
+            [[c[0], -s[0],  0,    0],
+            [s[0],  c[0],  0,    0],
+            [0,     0,     1,    0],
+            [0,     0,     0,    1]])
+    if ndim == 2 or np.size(rot) == 1:
+        A = np.dot(trans, xrot[:ndim + 1, :ndim + 1])
+    else:
+        yrot = [[c[1],  0,     s[1], 0,],
+                [0,     1,     0,    0],
+                [-s[1], 0,     c[1], 0],
+                [0,     0,     0,    1]]
+        zrot = [[1,     0,     0,    0],
+                [0,     c[2], -s[2], 0],
+                [0,     s[2],  c[2], 0],
+                [0,     0,     0,    1]]
+        A = np.dot(trans, np.dot(xrot, np.dot(yrot, zrot)))
+    return A
+
+# Dict of valid types of Transformations used by Lucas-Kanade
+TRANSFORMATION_TYPES = {
+    'Translation': TranslationTransformation,
+    'Euclidean': EuclideanTransformation
+}


### PR DESCRIPTION
This PR follows up on the initial work in #74 to incorporate more complex registration methods into thunder. As a precursor to a full RASL implementation, I've put together an implementation of the Lucas-Kande (LK) registration method for iterative registration. This method takes a volume and a reference, and iteratively updates the transformation parameters to minimize the difference between the transformed volume and the reference. It's a very old algorithm that is still popular and works pretty well. Checkout the original paper here:
https://cseweb.ucsd.edu/classes/sp02/cse252/lucaskanade81.pdf

With LK we can perform sub-voxel alignment and compute both translations and rotations. Adding support for other transformations like planar displacements or non-rigid deformations is easy, as you just need to expose a `jacobian` method that computes the change in pixels for each parameter (but regularization can get trickier).

Some of the additions to the existing transformations that were needed to get this working:
- `DifferentiableTransformation` class that has an `updateParams` and `jacobian` method
- `TranslationTransformation` and `EuclideanTransformation` class for supporting affine transformations parametrized by shifts and shifts + Euler angle rotations
- `GridTransformer` class that can transform a volume by an arbitrary affine transformation

Handy extensions:
- `robust` option that minimizes least absolute deviation instead of least squares
- instead of computing reconstruction error relative to one reference, we compute the reconstruction error between the transformed image and a weighting on the reference images. This allows us to pass in multiple reference images, which will be needed when we implement RASL.

It would be great to get some initial feedback on the structure of these additions and the interaction of transformations with the `GridTransformer` objects. These are needed to call `map_coordinates` so that we can perform arbitrary affine transformations of volumes in 3d, but require us to keep track of a set of points that is the same size as the volume. For this reason, I try to create this object once in `getTransform` and reuse it. But it ends up creating a pretty messy chain of a transformation's apply calling a grids `transform_vol`. Any better ideas are appreciated :)

Things that are still missing include:
- conformation to style guidelines and PEP8
- lots and lots of tests
- support for plane-by-plane registration
