### PR TITLE
Changed bracket behavior for Data

### DIFF
--- a/python/test/test_data.py
+++ b/python/test/test_data.py
@@ -100,8 +100,7 @@ class TestImagesGetters(PySparkTestCase):
         assert_true(array_equal(self.ary1, vals[0][1]))
 
         assert_raises(KeyError, self.images.__getitem__, 2)
-
-        assert_equals([], self.images[2:3])
+        assert_raises(KeyError, self.images.__getitem__, slice(2,3))
 
 
 class TestSeriesGetters(PySparkTestCase):
@@ -250,8 +249,8 @@ class TestSeriesGetters(PySparkTestCase):
         assert_true(array_equal(self.dataLocal[0][1], vals[0][1]))
         assert_true(array_equal(self.dataLocal[1][1], vals[1][1]))
 
-        # trying to getitem a key that doesn't exist returns None
-        assert_is_none(self.series[(25, 17)])
+        # trying to getitem a key that doesn't exist throws a KeyError
+        assert_raises(KeyError, self.series.__getitem__, (25, 17))
 
-        # passing a range that is completely out of bounds returns []
-        assert_equals([], self.series[2:3, :])
+        # passing a range that is completely out of bounds throws a KeyError
+        assert_raises(KeyError, self.series.__getitem__, (slice(2, 3), slice(None, None)))

--- a/python/test/test_data.py
+++ b/python/test/test_data.py
@@ -99,7 +99,7 @@ class TestImagesGetters(PySparkTestCase):
         assert_equals(0, vals[0][0])
         assert_true(array_equal(self.ary1, vals[0][1]))
 
-        assert_is_none(self.images[2])
+        assert_raises(KeyError, self.images.__getitem__, 2)
 
         assert_equals([], self.images[2:3])
 

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -242,10 +242,10 @@ class Data(object):
             if any([isinstance(slise, slice) for slise in item]):
                 isRangeQuery = True
 
-        if isRangeQuery:
-            return self.getRange(item)
-        else:
-            return self.get(item)
+        result = self.getRange(item) if isRangeQuery else self.get(item)
+        if (result is None) or (result == []):
+            raise KeyError("No value found for key: %s" % str(item))
+        return result
 
     def values(self):
         """ Return values, ignoring keys


### PR DESCRIPTION
The __getitem__ method on Data objects now raises an KeyError if a value is not found for the given
key. Previously it returned None.  The Data unit tests have been updated accordingly.