### PR TITLE
Modified sorting

### DIFF
--- a/python/test/test_data.py
+++ b/python/test/test_data.py
@@ -255,6 +255,7 @@ class TestSeriesGetters(PySparkTestCase):
         # passing a range that is completely out of bounds throws a KeyError
         assert_raises(KeyError, self.series.__getitem__, (slice(2, 3), slice(None, None)))
 
+
 class TestDataMethods(PySparkTestCase):
 
     def test_sortbykey(self):
@@ -282,7 +283,7 @@ class TestDataMethods(PySparkTestCase):
         out = data.sortByKey().keys().collect()
         assert(array_equal(out, [(0,), (1,), (2,)]))
 
-    def collect(self):
+    def test_collect(self):
 
         dataLocal = [
             ((0, 0), array([0])),
@@ -299,11 +300,11 @@ class TestDataMethods(PySparkTestCase):
 
         assert(array_equal(out, [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2]]))
 
-        out = data.collectKeysAsArray()
+        out = data.collectValuesAsArray()
 
-        assert(array_equal((out, [0, 1, 2, 3, 4, 5])))
+        assert(array_equal(out, [[0], [1], [2], [3], [4], [5]]))
 
-    def collect_with_sorting(self):
+    def test_collect_with_sorting(self):
 
         dataLocal = [
             ((0, 0), array([0])),
@@ -320,6 +321,8 @@ class TestDataMethods(PySparkTestCase):
 
         assert(array_equal(out, [[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]]))
 
-        out = data.collectKeysAsArray()
+        out = data.collectValuesAsArray(sorting=True)
 
-        assert(array_equal((out, [0, 3, 1, 4, 2, 5])))
+        print(out)
+
+        assert(array_equal(out, [[0], [3], [1], [4], [2], [5]]))

--- a/python/test/test_data.py
+++ b/python/test/test_data.py
@@ -254,3 +254,72 @@ class TestSeriesGetters(PySparkTestCase):
 
         # passing a range that is completely out of bounds throws a KeyError
         assert_raises(KeyError, self.series.__getitem__, (slice(2, 3), slice(None, None)))
+
+class TestDataMethods(PySparkTestCase):
+
+    def test_sortbykey(self):
+
+        dataLocal = [
+            ((0, 0), array([0])),
+            ((0, 1), array([0])),
+            ((0, 2), array([0])),
+            ((1, 0), array([0])),
+            ((1, 1), array([0])),
+            ((1, 2), array([0]))
+        ]
+
+        data = Data(self.sc.parallelize(dataLocal))
+        out = data.sortByKey().keys().collect()
+        assert(array_equal(out, [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (1, 2)]))
+
+        dataLocal = [
+            ((0,), array([0])),
+            ((1,), array([0])),
+            ((2,), array([0]))
+        ]
+
+        data = Data(self.sc.parallelize(dataLocal))
+        out = data.sortByKey().keys().collect()
+        assert(array_equal(out, [(0,), (1,), (2,)]))
+
+    def collect(self):
+
+        dataLocal = [
+            ((0, 0), array([0])),
+            ((0, 1), array([1])),
+            ((0, 2), array([2])),
+            ((1, 0), array([3])),
+            ((1, 1), array([4])),
+            ((1, 2), array([5]))
+        ]
+
+        data = Data(self.sc.parallelize(dataLocal))
+
+        out = data.collectKeysAsArray()
+
+        assert(array_equal(out, [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2]]))
+
+        out = data.collectKeysAsArray()
+
+        assert(array_equal((out, [0, 1, 2, 3, 4, 5])))
+
+    def collect_with_sorting(self):
+
+        dataLocal = [
+            ((0, 0), array([0])),
+            ((0, 1), array([1])),
+            ((0, 2), array([2])),
+            ((1, 0), array([3])),
+            ((1, 1), array([4])),
+            ((1, 2), array([5]))
+        ]
+
+        data = Data(self.sc.parallelize(dataLocal))
+
+        out = data.collectKeysAsArray(sorting=True)
+
+        assert(array_equal(out, [[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]]))
+
+        out = data.collectKeysAsArray()
+
+        assert(array_equal((out, [0, 3, 1, 4, 2, 5])))

--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -468,12 +468,12 @@ class Series(Data):
         if not (dtype is None):
             out = out.astype(dtype, casting)
 
-        result = out.rdd.map(lambda (_, v): v).collect()
-        nout = size(result[0])
-
         if sorting is True:
-            keys = out.subToInd().rdd.map(lambda (k, _): int(k)).collect()
-            result = array([v for (k, v) in sorted(zip(keys, result), key=lambda (k, v): k)])
+            result = out.sortByKey().values().collect()
+        else:
+            result = out.rdd.values().collect()
+
+        nout = size(result[0])
 
         # reshape into a dense array of shape (b, x, y, z)  or (b, x, y) or (b, x)
         # where b is the number of outputs per record

--- a/python/thunder/rdds/spatialseries.py
+++ b/python/thunder/rdds/spatialseries.py
@@ -96,6 +96,5 @@ class SpatialSeries(Series):
         # get correlations
         corr = result.mapValues(lambda x: corrcoef(x[0], x[1])[0, 1])
 
-        # force sorting, but reverse keys for correct ordering
-        output = corr.map(lambda (k, v): (k[::-1], v)).sortByKey().map(lambda (k, v): (k[::-1], v))
-        return Series(output, index='correlation').__finalize__(self)
+        # sort output because we expect shuffling to change ordering
+        return Series(corr, index='correlation').__finalize__(self).sortByKey()


### PR DESCRIPTION
This PR reorganizes support for sorting outputs, 

A couple key changes / hopefully improvements:

* The primary sorting behavior is relegated to a `Data` method `sortByKey()` that calls the underlying Spark RDD functions. This will make it easier to maintain / modify the sorting behavior and use it elsewhere.
* By using this function, sorting during `Series.pack()` is now done with RDD functions, which avoids an error by which collecting the keys and values separately (for driver-side sort) can yield different orderings.
* The `collect`, `collectAsArray`, `collectValuesAsArray`, and `collectKeysAsArray` methods all now take `sorting` as an input argument. This has previously been an option on `pack`, but it is useful as an option on these functions for non-contiguous data (as reported by @jwittenbach ).

I have not yet done performance testing on driver-side sorting versus `sortByKey()` but especially with improvements to shuffling in Spark 1.2 I expect it to be comparable if not better (it previously was the case that performance sorting smaller results especially was much better on the driver). If we do want to revert, with the new refactoring, we'll only need to make the switch in one place.

For sorting behavior consistent with other functionality / conventions in Thunder (fastest key changes first), I do reverse the ordering of the keys before (and after) sorting. The one consequence is that the sorting methods will break for integer keys. Keys are *supposed* to always be tuples, but we also don't / can't enforce that. Perhaps the sorting method should check to make sure the keys are iterable before sorting and if not, don't try to reverse?

cc @industrial-sloth 