### PR TITLE
Add programmatic setting of AWS credentials

### DIFF
--- a/python/test/test_seriesloader.py
+++ b/python/test/test_seriesloader.py
@@ -323,7 +323,7 @@ class TestSeriesBinaryLoader(PySparkTestCaseWithOutputDir):
 class TestSeriesBinaryWriteFromStack(PySparkTestCaseWithOutputDir):
 
     def _run_roundtrip_tst(self, testCount, arrays, blockSize):
-        print "Running TestSeriesBinaryWriteFromStack roundtrip test #%d" % testCount
+        #  print "Running TestSeriesBinaryWriteFromStack roundtrip test #%d" % testCount
         inSubdir = os.path.join(self.outputdir, 'input%d' % testCount)
         os.mkdir(inSubdir)
 

--- a/python/thunder/factorization/nmf.py
+++ b/python/thunder/factorization/nmf.py
@@ -202,6 +202,7 @@ class NMF(object):
 
             # report results
             self.h = h
+            # TODO: need to propagate metadata through to this new Series object
             self.w = Series(w)
 
         else:

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -60,6 +60,13 @@ class Data(object):
             self.populateParamsFromFirstRecord()
         return self._dtype
 
+    @property
+    def awsCredentials(self):
+        if self._awsCredentials is None:
+            from thunder.utils.common import AWSCredentials
+            return AWSCredentials()  # return instance with None, None as public and private keys
+        return self._awsCredentials
+
     def populateParamsFromFirstRecord(self):
         """
         Calls first() on the underlying rdd, using the returned record to determine appropriate attribute settings

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -17,12 +17,13 @@ class Data(object):
         directly exposed by the Data object can be accessed via `obj.rdd`.
     """
 
-    _metadata = ['_nrecords', '_dtype']
+    _metadata = ['_nrecords', '_dtype', '_awsCredentials']
 
-    def __init__(self, rdd, nrecords=None, dtype=None):
+    def __init__(self, rdd, nrecords=None, dtype=None, awsCredentials=None):
         self.rdd = rdd
         self._nrecords = nrecords
         self._dtype = dtype
+        self._awsCredentials = awsCredentials
 
     def __repr__(self):
         # start with class name

--- a/python/thunder/rdds/fileio/imagesloader.py
+++ b/python/thunder/rdds/fileio/imagesloader.py
@@ -46,7 +46,7 @@ class ImagesLoader(object):
         narrays = len(arrays)
         npartitions = min(narrays, npartitions) if npartitions else narrays
         return Images(self.sc.parallelize(enumerate(arrays), npartitions),
-                      dims=shape, dtype=str(dtype), nrecords=narrays)
+                      dims=shape, dtype=str(dtype), nrecords=narrays, awsCredentials=self.awsCredentialsOverride)
 
     def fromStack(self, dataPath, dims, dtype='int16', ext='stack', startIdx=None, stopIdx=None, recursive=False,
                   nplanes=None, npartitions=None):
@@ -130,7 +130,8 @@ class ImagesLoader(object):
                                 npartitions=npartitions)
         nrecords = reader.lastNRecs if nplanes is None else None
         newDims = tuple(list(dims[:-1]) + [nplanes]) if nplanes else dims
-        return Images(readerRdd.flatMap(toArray), nrecords=nrecords, dims=newDims, dtype=dtype)
+        return Images(readerRdd.flatMap(toArray), nrecords=nrecords, dims=newDims, dtype=dtype,
+                      awsCredentials=self.awsCredentialsOverride)
 
     def fromTif(self, dataPath, ext='tif', startIdx=None, stopIdx=None, recursive=False, nplanes=None,
                 npartitions=None):
@@ -237,7 +238,7 @@ class ImagesLoader(object):
         readerRdd = reader.read(dataPath, ext=ext, startIdx=startIdx, stopIdx=stopIdx, recursive=recursive,
                                 npartitions=npartitions)
         nrecords = reader.lastNRecs if nplanes is None else None
-        return Images(readerRdd.flatMap(multitifReader), nrecords=nrecords)
+        return Images(readerRdd.flatMap(multitifReader), nrecords=nrecords, awsCredentials=self.awsCredentialsOverride)
 
     def fromPng(self, dataPath, ext='png', startIdx=None, stopIdx=None, recursive=False, npartitions=None):
         """Load an Images object stored in a directory of png files
@@ -275,4 +276,5 @@ class ImagesLoader(object):
         reader = getParallelReaderForPath(dataPath)(self.sc, awsCredentialsOverride=self.awsCredentialsOverride)
         readerRdd = reader.read(dataPath, ext=ext, startIdx=startIdx, stopIdx=stopIdx, recursive=recursive,
                                 npartitions=npartitions)
-        return Images(readerRdd.mapValues(readPngFromBuf), nrecords=reader.lastNRecs)
+        return Images(readerRdd.mapValues(readPngFromBuf), nrecords=reader.lastNRecs,
+                      awsCredentials=self.awsCredentialsOverride)

--- a/python/thunder/rdds/fileio/readers.py
+++ b/python/thunder/rdds/fileio/readers.py
@@ -122,7 +122,9 @@ def _localRead(filePath, startOffset=None, size=-1):
 class LocalFSParallelReader(object):
     """Parallel reader backed by python's native file() objects.
     """
-    def __init__(self, sparkContext):
+    def __init__(self, sparkContext, **kwargs):
+        # kwargs allow AWS credentials to be passed into generic Readers w/o exceptions being raised
+        # in this case kwargs are just ignored
         self.sc = sparkContext
         self.lastNRecs = None
 
@@ -272,23 +274,29 @@ class _BotoS3Client(object):
         else:
             return results
 
-    def __init__(self):
+    def __init__(self, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
         """Initialization; validates that AWS keys are available as environment variables.
 
         Will let boto library look up credentials itself according to its own rules - e.g. first looking for
         AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, then going through several possible config files and finally
         looking for a ~/.aws/credentials .ini-formatted file. See boto docs:
         http://boto.readthedocs.org/en/latest/boto_config_tut.html
+
+        However, if the `awsAccessKeyId` and `awsSecretAccessKey` parameters are
+        not None, these values will be used instead of those found by the standard boto credential lookup process.
         """
         if not _haveBoto:
             raise ValueError("The boto package does not appear to be available; boto is required for BotoS3Reader")
+        self.awsAccessKeyIdOverride = awsAccessKeyIdOverride
+        self.awsSecretAccessKeyOverride = awsSecretAccessKeyOverride
 
 
 class BotoS3ParallelReader(_BotoS3Client):
     """Parallel reader backed by boto AWS client library.
     """
-    def __init__(self, sparkContext):
-        super(BotoS3ParallelReader, self).__init__()
+    def __init__(self, sparkContext, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
+        super(BotoS3ParallelReader, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
+                                                   awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
         self.sc = sparkContext
         self.lastNRecs = None
 
@@ -302,7 +310,8 @@ class BotoS3ParallelReader(_BotoS3Client):
             raise NotImplementedError("Recursive traversal of directories isn't yet implemented for S3 - sorry!")
         parse = _BotoS3Client.parseS3Query(dataPath)
 
-        conn = boto.connect_s3()
+        conn = boto.connect_s3(aws_access_key_id=self.awsAccessKeyIdOverride,
+                               aws_secret_access_key=self.awsSecretAccessKeyOverride)
         bucket = conn.get_bucket(parse[0])
         keys = _BotoS3Client.retrieveKeys(bucket, parse[1], prefix=parse[2], postfix=parse[3])
         keyNameList = [key.name for key in keys]
@@ -326,8 +335,13 @@ class BotoS3ParallelReader(_BotoS3Client):
         if not keyNameList:
             raise FileNotFoundError("No S3 objects found for '%s'" % dataPath)
 
+        # try to prevent self from getting pulled into the closure
+        awsAccessKeyIdOverride_ = self.awsAccessKeyIdOverride
+        awsSecretAccessKeyOverride_ = self.awsSecretAccessKeyOverride
+
         def readSplitFromS3(kvIter):
-            conn = boto.connect_s3()
+            conn = boto.connect_s3(aws_access_key_id=awsAccessKeyIdOverride_,
+                                   aws_secret_access_key=awsSecretAccessKeyOverride_)
             bucket = conn.get_bucket(bucketName)
             for kv in kvIter:
                 idx, keyName = kv
@@ -343,6 +357,10 @@ class BotoS3ParallelReader(_BotoS3Client):
 class LocalFSFileReader(object):
     """File reader backed by python's native file() objects.
     """
+    def __init__(self, **kwargs):
+        # do nothing; allows AWS access keys to be passed in to a generic Reader instance w/o blowing up
+        pass
+
     def __listRecursive(self, dataPath):
         if os.path.isdir(dataPath):
             dirname = dataPath
@@ -416,7 +434,8 @@ class BotoS3FileReader(_BotoS3Client):
     """
     def __getMatchingKeys(self, dataPath, filename=None):
         parse = _BotoS3Client.parseS3Query(dataPath)
-        conn = boto.connect_s3()
+        conn = boto.connect_s3(aws_access_key_id=self.awsAccessKeyIdOverride,
+                               aws_secret_access_key=self.awsSecretAccessKeyOverride)
         bucketName = parse[0]
         keyName = parse[1]
         bucket = conn.get_bucket(bucketName)

--- a/python/thunder/rdds/fileio/seriesloader.py
+++ b/python/thunder/rdds/fileio/seriesloader.py
@@ -590,7 +590,7 @@ class SeriesLoader(object):
     def __saveSeriesRdd(self, seriesBlocks, outputDirPath, dims, npointsInSeries, dtype, overwrite=False):
         if not overwrite:
             from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            raiseErrorIfPathExists(outputDirPath, awsCredentialsOverride=self.awsCredentialsOverride)
             overwrite = True  # prevent additional downstream checks for this path
         writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite,
                                                          awsCredentialsOverride=self.awsCredentialsOverride)
@@ -657,7 +657,7 @@ class SeriesLoader(object):
         """
         if not overwrite:
             from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            raiseErrorIfPathExists(outputDirPath, awsCredentialsOverride=self.awsCredentialsOverride)
             overwrite = True  # prevent additional downstream checks for this path
 
         seriesBlocks, npointsInSeries, newDtype = \
@@ -706,7 +706,7 @@ class SeriesLoader(object):
         """
         if not overwrite:
             from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            raiseErrorIfPathExists(outputDirPath, self.awsCredentialsOverride)
             overwrite = True  # prevent additional downstream checks for this path
 
         seriesBlocks, metadata = self._getSeriesBlocksFromMultiTif(dataPath, ext=ext, blockSize=blockSize,

--- a/python/thunder/rdds/fileio/seriesloader.py
+++ b/python/thunder/rdds/fileio/seriesloader.py
@@ -140,7 +140,7 @@ class SeriesLoader(object):
         -------
         BinaryLoadParameters instance
         """
-        params = SeriesLoader.loadConf(dataPath, confFilename=confFilename)
+        params = self.loadConf(dataPath, confFilename=confFilename)
 
         # filter dict to include only recognized field names:
         for k in params.keys():

--- a/python/thunder/rdds/fileio/writers.py
+++ b/python/thunder/rdds/fileio/writers.py
@@ -28,6 +28,7 @@ import urllib
 import urlparse
 
 from thunder.rdds.fileio.readers import _BotoS3Client, getByScheme
+from thunder.utils.common import AWSCredentials
 
 
 _haveBoto = False
@@ -39,7 +40,7 @@ except ImportError:
 
 
 class LocalFSParallelWriter(object):
-    def __init__(self, dataPath, overwrite=False):
+    def __init__(self, dataPath, overwrite=False, **kwargs):
         self._dataPath = dataPath
         # thanks stack overflow:
         # http://stackoverflow.com/questions/5977576/is-there-a-convenient-way-to-map-a-file-uri-to-os-path
@@ -68,10 +69,8 @@ class LocalFSParallelWriter(object):
 
 
 class _BotoS3Writer(_BotoS3Client):
-    def __init__(self, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
-        super(_BotoS3Writer, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
-                                            awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
-
+    def __init__(self, awsCredentialsOverride=None):
+        super(_BotoS3Writer, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._contextActive = False
         self._conn = None
         self._keyName = None
@@ -82,8 +81,7 @@ class _BotoS3Writer(_BotoS3Client):
         Set up a boto s3 connection.
 
         """
-        conn = boto.connect_s3(aws_access_key_id=self.awsAccessKeyIdOverride,
-                               aws_secret_access_key=self.awsSecretAccessKeyOverride)
+        conn = boto.connect_s3(**AWSCredentials.getCredentialsAsDict(self.awsCredentialsOverride))
         parsed = _BotoS3Client.parseS3Query(dataPath)
         bucketName = parsed[0]
         keyName = parsed[1]
@@ -110,9 +108,8 @@ class _BotoS3Writer(_BotoS3Client):
 
 
 class BotoS3ParallelWriter(_BotoS3Writer):
-    def __init__(self, dataPath, overwrite=False, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
-        super(BotoS3ParallelWriter, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
-                                                   awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
+    def __init__(self, dataPath, overwrite=False, awsCredentialsOverride=None):
+        super(BotoS3ParallelWriter, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._dataPath = dataPath
         self._overwrite = overwrite
 
@@ -151,10 +148,8 @@ class LocalFSFileWriter(object):
 
 
 class BotoS3FileWriter(_BotoS3Writer):
-    def __init__(self, dataPath, filename, overwrite=False, awsAccessKeyIdOverride=None,
-                 awsSecretAccessKeyOverride=None):
-        super(BotoS3FileWriter, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
-                                               awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
+    def __init__(self, dataPath, filename, overwrite=False, awsCredentialsOverride=None):
+        super(BotoS3FileWriter, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._dataPath = dataPath
         self._filename = filename
         self._overwrite = overwrite
@@ -199,9 +194,8 @@ class LocalFSCollectedFileWriter(object):
 
 class BotoS3CollectedFileWriter(_BotoS3Writer):
     # todo: needs to check before writing if overwrite is True
-    def __init__(self, dataPath, overwrite=False, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
-        super(BotoS3CollectedFileWriter, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
-                                                        awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
+    def __init__(self, dataPath, overwrite=False, awsCredentialsOverride=None):
+        super(BotoS3CollectedFileWriter, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._dataPath = dataPath
         self._overwrite = overwrite
 

--- a/python/thunder/rdds/fileio/writers.py
+++ b/python/thunder/rdds/fileio/writers.py
@@ -68,8 +68,9 @@ class LocalFSParallelWriter(object):
 
 
 class _BotoS3Writer(_BotoS3Client):
-    def __init__(self):
-        super(_BotoS3Writer, self).__init__()
+    def __init__(self, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
+        super(_BotoS3Writer, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
+                                            awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
 
         self._contextActive = False
         self._conn = None
@@ -81,7 +82,8 @@ class _BotoS3Writer(_BotoS3Client):
         Set up a boto s3 connection.
 
         """
-        conn = boto.connect_s3()
+        conn = boto.connect_s3(aws_access_key_id=self.awsAccessKeyIdOverride,
+                               aws_secret_access_key=self.awsSecretAccessKeyOverride)
         parsed = _BotoS3Client.parseS3Query(dataPath)
         bucketName = parsed[0]
         keyName = parsed[1]
@@ -108,8 +110,9 @@ class _BotoS3Writer(_BotoS3Client):
 
 
 class BotoS3ParallelWriter(_BotoS3Writer):
-    def __init__(self, dataPath, overwrite=False):
-        super(BotoS3ParallelWriter, self).__init__()
+    def __init__(self, dataPath, overwrite=False, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
+        super(BotoS3ParallelWriter, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
+                                                   awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
         self._dataPath = dataPath
         self._overwrite = overwrite
 
@@ -124,7 +127,7 @@ class BotoS3ParallelWriter(_BotoS3Writer):
 
 
 class LocalFSFileWriter(object):
-    def __init__(self, dataPath, filename, overwrite=False):
+    def __init__(self, dataPath, filename, overwrite=False, **kwargs):
         self._dataPath = dataPath
         self._filename = filename
         self._absPath = os.path.join(urllib.url2pathname(urlparse.urlparse(dataPath).path), filename)
@@ -148,8 +151,10 @@ class LocalFSFileWriter(object):
 
 
 class BotoS3FileWriter(_BotoS3Writer):
-    def __init__(self, dataPath, filename, overwrite=False):
-        super(BotoS3FileWriter, self).__init__()
+    def __init__(self, dataPath, filename, overwrite=False, awsAccessKeyIdOverride=None,
+                 awsSecretAccessKeyOverride=None):
+        super(BotoS3FileWriter, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
+                                               awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
         self._dataPath = dataPath
         self._filename = filename
         self._overwrite = overwrite
@@ -164,7 +169,7 @@ class BotoS3FileWriter(_BotoS3Writer):
 
 
 class LocalFSCollectedFileWriter(object):
-    def __init__(self, dataPath, overwrite=False):
+    def __init__(self, dataPath, overwrite=False, **kwargs):
         self._dataPath = dataPath
         self._absPath = urllib.url2pathname(urlparse.urlparse(dataPath).path)
         self._overwrite = overwrite
@@ -194,8 +199,9 @@ class LocalFSCollectedFileWriter(object):
 
 class BotoS3CollectedFileWriter(_BotoS3Writer):
     # todo: needs to check before writing if overwrite is True
-    def __init__(self, dataPath, overwrite=False):
-        super(BotoS3CollectedFileWriter, self).__init__()
+    def __init__(self, dataPath, overwrite=False, awsAccessKeyIdOverride=None, awsSecretAccessKeyOverride=None):
+        super(BotoS3CollectedFileWriter, self).__init__(awsAccessKeyIdOverride=awsAccessKeyIdOverride,
+                                                        awsSecretAccessKeyOverride=awsSecretAccessKeyOverride)
         self._dataPath = dataPath
         self._overwrite = overwrite
 

--- a/python/thunder/rdds/images.py
+++ b/python/thunder/rdds/images.py
@@ -103,7 +103,8 @@ class Images(Data):
         groupedvals = vals.groupBy(lambda (k, _): k.spatialKey).sortBy(lambda (k, _): tuple(k[::-1]))
         # groupedvals is now rdd of (z, y, x spatial key, [(partitioning key, numpy array)...]
         blockedvals = groupedvals.map(blockingStrategy.combiningFunction)
-        return returntype(blockedvals, dims=self.dims, nimages=self.nrecords, dtype=self.dtype)
+        return returntype(blockedvals, dims=self.dims, nimages=self.nrecords, dtype=self.dtype,
+                          awsCredentials=self._awsCredentials)
 
     def toSeries(self, blockSizeSpec="150M", units="pixels"):
         """Converts this Images object to a Series object.
@@ -215,10 +216,12 @@ class Images(Data):
         bufRdd = self.rdd.map(toFilenameAndPngBuf)
 
         if collectToDriver:
-            writer = getCollectedFileWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite)
+            writer = getCollectedFileWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite,
+                                                                  awsCredentialsOverride=self._awsCredentials)
             writer.writeCollectedFiles(bufRdd.collect())
         else:
-            writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite)
+            writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite,
+                                                             awsCredentialsOverride=self._awsCredentials)
             bufRdd.foreach(writer.writerFcn)
 
     def maxProjection(self, axis=2):

--- a/python/thunder/rdds/images.py
+++ b/python/thunder/rdds/images.py
@@ -166,7 +166,7 @@ class Images(Data):
         """
         if not overwrite:
             from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            raiseErrorIfPathExists(outputDirPath, awsCredentialsOverride=self._awsCredentials)
             overwrite = True  # prevent additional downstream checks for this path
 
         self.toBlocks(blockSizeSpec, units=units).saveAsBinarySeries(outputDirPath, overwrite=overwrite)

--- a/python/thunder/rdds/images.py
+++ b/python/thunder/rdds/images.py
@@ -15,8 +15,8 @@ class Images(Data):
 
     _metadata = Data._metadata + ['_dims']
 
-    def __init__(self, rdd, dims=None, nrecords=None, dtype=None):
-        super(Images, self).__init__(rdd, nrecords=nrecords, dtype=dtype)
+    def __init__(self, rdd, dims=None, nrecords=None, dtype=None, awsCredentials=None):
+        super(Images, self).__init__(rdd, nrecords=nrecords, dtype=dtype, awsCredentials=awsCredentials)
         if dims and not isinstance(dims, Dimensions):
             try:
                 dims = Dimensions.fromTuple(dims)

--- a/python/thunder/rdds/imgblocks/blocks.py
+++ b/python/thunder/rdds/imgblocks/blocks.py
@@ -113,16 +113,17 @@ class Blocks(Data):
 
         if not overwrite:
             from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            raiseErrorIfPathExists(outputDirPath, awsCredentialsOverride=self._awsCredentials)
             overwrite = True  # prevent additional downstream checks for this path
 
-        writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite)
+        writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite,
+                                                         awsCredentialsOverride=self._awsCredentials)
 
         binseriesRdd = self.toBinarySeries()
 
         binseriesRdd.foreach(writer.writerFcn)
         writeSeriesConfig(outputDirPath, len(self.dims), self.nimages, keyType='int16', valueType=self.dtype,
-                          overwrite=overwrite)
+                          overwrite=overwrite, awsCredentialsOverride=self._awsCredentials)
 
 
 class SimpleBlocks(Blocks):
@@ -210,14 +211,16 @@ class SimpleBlocks(Blocks):
         seriesRdd = self.rdd.flatMap(lambda kv: SimpleBlocks._toSeriesIter(kv[0], kv[1]))
 
         idx = arange(self._nimages) if self._nimages else None
-        return Series(seriesRdd, dims=self.dims, index=idx, dtype=self.dtype).astype(newDType, casting=casting)
+        return Series(seriesRdd, dims=self.dims, index=idx, dtype=self.dtype, awsCredentials=self._awsCredentials)\
+            .astype(newDType, casting=casting)
 
     def toImages(self):
         from thunder.rdds.images import Images
         timeRdd = self.rdd.flatMap(lambda kv: SimpleBlocks._toTimeSlicedBlocksIter(kv[0], kv[1]))
         timeSortedRdd = timeRdd.groupBy(lambda (k, _): k.temporalKey).sortByKey()
         imagesRdd = timeSortedRdd.map(SimpleBlocks._combineTimeSlicedBlocks)
-        return Images(imagesRdd, dims=self._dims, nrecords=self._nimages, dtype=self._dtype)
+        return Images(imagesRdd, dims=self._dims, nrecords=self._nimages, dtype=self._dtype,
+                      awsCredentials=self._awsCredentials)
 
     @staticmethod
     def getBinarySeriesNameForKey(blockKey):

--- a/python/thunder/rdds/imgblocks/blocks.py
+++ b/python/thunder/rdds/imgblocks/blocks.py
@@ -49,8 +49,8 @@ class Blocks(Data):
     """
     _metadata = Data._metadata + ['_dims', '_nimages']
 
-    def __init__(self, rdd, dims=None, nimages=None, dtype=None):
-        super(Blocks, self).__init__(rdd, dtype=dtype)
+    def __init__(self, rdd, dims=None, nimages=None, dtype=None, awsCredentials=None):
+        super(Blocks, self).__init__(rdd, dtype=dtype, awsCredentials=awsCredentials)
         self._dims = dims
         self._nimages = nimages
 

--- a/python/thunder/rdds/matrices.py
+++ b/python/thunder/rdds/matrices.py
@@ -4,7 +4,6 @@ Class with utilities for representing and working with matrices
 from numpy import dot, outer, shape, ndarray, add, subtract, multiply, zeros, divide, arange
 
 from thunder.rdds.series import Series
-from thunder.rdds.data import Data
 
 
 # TODO: right divide and left divide
@@ -40,7 +39,8 @@ class RowMatrix(Series):
 
     _metadata = Series._metadata + ['_ncols', '_nrows']
 
-    def __init__(self, rdd, index=None, dims=None, dtype=None, nrows=None, ncols=None, nrecords=None):
+    def __init__(self, rdd, index=None, dims=None, dtype=None, nrows=None, ncols=None, nrecords=None,
+                 awsCredentials=None):
         if nrows is not None and nrecords is not None:
             if nrows != nrecords:
                 raise ValueError("nrows and nrecords must be consistent, got %d and %d" % (nrows, nrecords))
@@ -51,7 +51,8 @@ class RowMatrix(Series):
                                      (ncols, len(index)))
         elif ncols is not None:
             index = arange(ncols)
-        super(RowMatrix, self).__init__(rdd, nrecords=nrecs, dtype=dtype, dims=dims, index=index)
+        super(RowMatrix, self).__init__(rdd, nrecords=nrecs, dtype=dtype, dims=dims, index=index,
+                                        awsCredentials=awsCredentials)
 
     @property
     def nrows(self):

--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -41,8 +41,8 @@ class Series(Data):
 
     _metadata = Data._metadata + ['_dims', '_index']
 
-    def __init__(self, rdd, nrecords=None, dtype=None, index=None, dims=None):
-        super(Series, self).__init__(rdd, nrecords=nrecords, dtype=dtype)
+    def __init__(self, rdd, nrecords=None, dtype=None, awsCredentials=None, index=None, dims=None):
+        super(Series, self).__init__(rdd, nrecords=nrecords, dtype=dtype, awsCredentials=None)
         self._index = None
         if index is not None:
             self.index = index

--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -42,7 +42,7 @@ class Series(Data):
     _metadata = Data._metadata + ['_dims', '_index']
 
     def __init__(self, rdd, nrecords=None, dtype=None, awsCredentials=None, index=None, dims=None):
-        super(Series, self).__init__(rdd, nrecords=nrecords, dtype=dtype, awsCredentials=None)
+        super(Series, self).__init__(rdd, nrecords=nrecords, dtype=dtype, awsCredentials=awsCredentials)
         self._index = None
         if index is not None:
             self.index = index
@@ -790,7 +790,8 @@ class Series(Data):
         # <key>, <val> at this point is:
         # <block number>, <[(series key, series val), (series key, series val), ...]>
         simpleBlocksRdd = groupedRdd.map(blockingStrategy.combiningFunction)
-        return returnType(simpleBlocksRdd, dims=self.dims, nimages=len(self.index), dtype=self.dtype)
+        return returnType(simpleBlocksRdd, dims=self.dims, nimages=len(self.index), dtype=self.dtype,
+                          awsCredentials=self._awsCredentials)
 
     def saveAsBinarySeries(self, outputdirname, overwrite=False):
         """Writes out Series-formatted data.
@@ -825,7 +826,7 @@ class Series(Data):
 
         if not overwrite:
             from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputdirname)
+            raiseErrorIfPathExists(outputdirname, awsCredentialsOverride=self._awsCredentials)
             overwrite = True  # prevent additional downstream checks for this path
 
         def partitionToBinarySeries(kvIter):
@@ -850,7 +851,8 @@ class Series(Data):
                 label = SimpleBlocks.getBinarySeriesNameForKey(firstKey) + ".bin"
                 return iter([(label, val)])
 
-        writer = getParallelWriterForPath(outputdirname)(outputdirname, overwrite=overwrite)
+        writer = getParallelWriterForPath(outputdirname)(outputdirname, overwrite=overwrite,
+                                                         awsCredentialsOverride=self._awsCredentials)
 
         binseriesrdd = self.rdd.mapPartitions(partitionToBinarySeries)
 
@@ -860,7 +862,7 @@ class Series(Data):
         # be cached in _nkeys and _nvals attributes, removing the need for this .first() call in most cases.
         firstKey, firstVal = self.first()
         writeSeriesConfig(outputdirname, len(firstKey), len(firstVal), keyType='int16', valueType=self.dtype,
-                          overwrite=overwrite)
+                          overwrite=overwrite, awsCredentialsOverride=self._awsCredentials)
 
     def toRowMatrix(self):
         """

--- a/python/thunder/utils/common.py
+++ b/python/thunder/utils/common.py
@@ -190,3 +190,23 @@ def raiseErrorIfPathExists(path):
     if existing:
         raise ValueError("Path %s appears to already exist. Specify a new directory, or call " % path +
                          "with overwrite=True to overwrite.")
+
+
+class AWSCredentials(object):
+    __slots__ = ('awsAccessKeyId', 'awsSecretAccessKey')
+
+    def __init__(self, awsAccessKeyId=None, awsSecretAccessKey=None):
+        self.awsAccessKeyId = awsAccessKeyId
+        self.awsSecretAccessKey = awsSecretAccessKey
+
+    @staticmethod
+    def getCredentials(awsCredentials):
+        if awsCredentials:
+            return awsCredentials.awsAccessKeyId, awsCredentials.awsSecretAccessKey
+        else:
+            return None, None
+
+    @staticmethod
+    def getCredentialsAsDict(awsCredentials):
+        access, secret = AWSCredentials.getCredentials(awsCredentials)
+        return {"aws_access_key_id": access, "aws_secret_access_key": secret}

--- a/python/thunder/utils/common.py
+++ b/python/thunder/utils/common.py
@@ -199,6 +199,12 @@ class AWSCredentials(object):
         self.awsAccessKeyId = awsAccessKeyId
         self.awsSecretAccessKey = awsSecretAccessKey
 
+    def __repr__(self):
+        def obfuscate(s):
+            return "None" if s is None else "<%d-char string>" % len(s)
+        return "AWSCredentials(accessKeyId: %s, secretAccessKey: %s)" % \
+               (obfuscate(self.awsAccessKeyId), obfuscate(self.awsSecretAccessKey))
+
     @staticmethod
     def getCredentials(awsCredentials):
         if awsCredentials:

--- a/python/thunder/utils/common.py
+++ b/python/thunder/utils/common.py
@@ -177,7 +177,7 @@ def parseMemoryString(memStr):
         return int(memStr)
 
 
-def raiseErrorIfPathExists(path):
+def raiseErrorIfPathExists(path, awsCredentialsOverride=None):
     """Raises a ValueError if the passed path string is found to already exist.
 
     The ValueError message will suggest calling with overwrite=True; this function is expected to be
@@ -185,7 +185,7 @@ def raiseErrorIfPathExists(path):
     """
     # check that specified output path does not already exist
     from thunder.rdds.fileio.readers import getFileReaderForPath
-    reader = getFileReaderForPath(path)()
+    reader = getFileReaderForPath(path)(awsCredentialsOverride=awsCredentialsOverride)
     existing = reader.list(path, includeDirectories=True)
     if existing:
         raise ValueError("Path %s appears to already exist. Specify a new directory, or call " % path +

--- a/python/thunder/utils/context.py
+++ b/python/thunder/utils/context.py
@@ -25,8 +25,7 @@ class ThunderContext():
 
     def __init__(self, sparkcontext):
         self._sc = sparkcontext
-        self.awsAccessKeyId = None
-        self.awsSecretAccessKey = None
+        self.awsCredentials = None
 
     @classmethod
     def start(cls, *args, **kwargs):
@@ -614,8 +613,8 @@ class ThunderContext():
         awsAccessKeyId: string AWS public key, usually starts with "AKIA"
         awsSecretAccessKey: string AWS private key
         """
-        self.awsAccessKeyId = awsAccessKeyId
-        self.awsSecretAccessKey = awsSecretAccessKey
+        from thunder.utils.common import AWSCredentials
+        self.awsCredentials = AWSCredentials(awsAccessKeyId, awsSecretAccessKey)
         self._sc._jsc.hadoopConfiguration().set("fs.s3n.awsAccessKeyId", awsAccessKeyId)
         self._sc._jsc.hadoopConfiguration().set("fs.s3n.awsSecretAccessKey", awsSecretAccessKey)
 

--- a/python/thunder/utils/context.py
+++ b/python/thunder/utils/context.py
@@ -15,10 +15,18 @@ class ThunderContext():
     ----------
     `_sc` : SparkContext
         Spark context for Spark functionality
+
+    awsAccessKeyId: None, or string
+    awsSecretAccessKey: None, or string
+        Public and private keys for AWS services. Typically the credentials should be accessible
+        through any of several different configuration files, and so should not have to be set
+        on the ThunderContext. See setAWSCredentials().
     """
 
     def __init__(self, sparkcontext):
         self._sc = sparkcontext
+        self.awsAccessKeyId = None
+        self.awsSecretAccessKey = None
 
     @classmethod
     def start(cls, *args, **kwargs):
@@ -589,6 +597,28 @@ class ThunderContext():
             data = loader.fromNpyLocal(dataFilePath, keyFilePath)
 
         return data
+
+    def setAWSCredentials(self, awsAccessKeyId, awsSecretAccessKey):
+        """Manually set AWS access credentials to be used by Thunder.
+
+        This method is provided primarily for hosted environments that do not provide
+        filesystem access (e.g. Databricks Cloud). Typically AWS credentials can be set
+        and read from core-site.xml (for Hadoop input format readers, such as Series
+        binary files), ~/.boto or other boto credential file locations, or the environment
+        variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. These credentials should
+        be configured automatically in clusters launched by the thunder-ec2 script, and
+        so this method should not have to be called.
+
+        Parameters
+        ----------
+        awsAccessKeyId: string AWS public key, usually starts with "AKIA"
+        awsSecretAccessKey: string AWS private key
+        """
+        self.awsAccessKeyId = awsAccessKeyId
+        self.awsSecretAccessKey = awsSecretAccessKey
+        self._sc._jsc.hadoopConfiguration().set("fs.s3n.awsAccessKeyId", awsAccessKeyId)
+        self._sc._jsc.hadoopConfiguration().set("fs.s3n.awsSecretAccessKey", awsSecretAccessKey)
+
 
 DEFAULT_EXTENSIONS = {
     "stack": "stack",

--- a/python/thunder/utils/context.py
+++ b/python/thunder/utils/context.py
@@ -82,7 +82,7 @@ class ThunderContext():
         checkParams(inputFormat, ['text', 'binary'])
 
         from thunder.rdds.fileio.seriesloader import SeriesLoader
-        loader = SeriesLoader(self._sc, minPartitions=minPartitions)
+        loader = SeriesLoader(self._sc, minPartitions=minPartitions, awsCredentialsOverride=self.awsCredentials)
 
         if inputFormat.lower() == 'text':
             data = loader.fromText(dataPath, nkeys=nkeys)
@@ -171,7 +171,7 @@ class ThunderContext():
         checkParams(inputFormat, ['stack', 'png', 'tif', 'tif-stack'])
 
         from thunder.rdds.fileio.imagesloader import ImagesLoader
-        loader = ImagesLoader(self._sc)
+        loader = ImagesLoader(self._sc, awsCredentialsOverride=self.awsCredentials)
 
         if not ext:
             ext = DEFAULT_EXTENSIONS.get(inputFormat.lower(), None)
@@ -296,7 +296,7 @@ class ThunderContext():
 
         if shuffle:
             from thunder.rdds.fileio.imagesloader import ImagesLoader
-            loader = ImagesLoader(self._sc)
+            loader = ImagesLoader(self._sc, awsCredentialsOverride=self.awsCredentials)
             if inputFormat.lower() == 'stack':
                 images = loader.fromStack(dataPath, dims, dtype=dtype, ext=ext, startIdx=startIdx, stopIdx=stopIdx,
                                           recursive=recursive, nplanes=nplanes, npartitions=npartitions)
@@ -313,7 +313,7 @@ class ThunderContext():
             if npartitions is not None:
                 raise NotImplementedError("npartitions is not supported with shuffle=False")
 
-            loader = SeriesLoader(self._sc)
+            loader = SeriesLoader(self._sc, awsCredentialsOverride=self.awsCredentials)
             if inputFormat.lower() == 'stack':
                 return loader.fromStack(dataPath, dims, ext=ext, dtype=dtype, blockSize=blockSize,
                                         startIdx=startIdx, stopIdx=stopIdx, recursive=recursive)
@@ -442,7 +442,7 @@ class ThunderContext():
 
         if shuffle:
             from thunder.rdds.fileio.imagesloader import ImagesLoader
-            loader = ImagesLoader(self._sc)
+            loader = ImagesLoader(self._sc, awsCredentialsOverride=self.awsCredentials)
             if inputFormat.lower() == 'stack':
                 images = loader.fromStack(dataPath, dims, dtype=dtype, startIdx=startIdx, stopIdx=stopIdx,
                                           recursive=recursive, nplanes=nplanes, npartitions=npartitions)
@@ -457,7 +457,7 @@ class ThunderContext():
                 raise NotImplementedError("nplanes is not supported with shuffle=False")
             if npartitions is not None:
                 raise NotImplementedError("npartitions is not supported with shuffle=False")
-            loader = SeriesLoader(self._sc)
+            loader = SeriesLoader(self._sc, awsCredentialsOverride=self.awsCredentials)
             if inputFormat.lower() == 'stack':
                 loader.saveFromStack(dataPath, outputDirPath, dims, ext=ext, dtype=dtype,
                                      blockSize=blockSize, overwrite=overwrite, startIdx=startIdx,
@@ -586,7 +586,7 @@ class ThunderContext():
         checkParams(inputFormat, ['mat', 'npy'])
 
         from thunder.rdds.fileio.seriesloader import SeriesLoader
-        loader = SeriesLoader(self._sc, minPartitions=minPartitions)
+        loader = SeriesLoader(self._sc, minPartitions=minPartitions, awsCredentialsOverride=self.awsCredentials)
 
         if inputFormat.lower() == 'mat':
             if varName is None:

--- a/python/thunder/utils/context.py
+++ b/python/thunder/utils/context.py
@@ -434,7 +434,7 @@ class ThunderContext():
                              " ('stack' value for 'inputFormat' parameter)")
 
         if not overwrite:
-            raiseErrorIfPathExists(outputDirPath)
+            raiseErrorIfPathExists(outputDirPath, awsCredentialsOverride=self.awsCredentials)
             overwrite = True  # prevent additional downstream checks for this path
 
         if not ext:


### PR DESCRIPTION
AWS credentials are required to access S3. Typically these credentials end up in two locations - first, they're put in a `core-site.xml` file, where they're read out and used by the Hadoop InputFormat readers, which in Thunder primarily come in when reading binary Series data. For other access to S3, we use the `boto` module, which looks for credentials in a couple different places, including environment variables and a `.boto` config file. In the `thunder-ec2` script we write out these credentials to a `.boto` file and push this file out to all workers.

So far so good. The problem comes in when running in managed environments that don't give direct access to the cluster node file systems, such as the new Databricks Cloud. Here we can push out credentials to be used by the Hadoop readers by something like the following:
```python
sc._jsc.hadoopConfiguration().set("fs.s3n.awsAccessKeyId", ACCESS_KEY)
sc._jsc.hadoopConfiguration().set("fs.s3n.awsSecretAccessKey", SECRET_KEY)
```
But we don't have a good solution (or any solution, really) for getting the AWS credentials out where they can be used by boto on the workers. So, at the moment, on Databricks Cloud most attempts to access S3 fail once a worker node attempts to connect and discovers that it doesn't have the AWS credentials.

The "solution" implemented in this PR is to add a new `setAWSCredentials` method on the ThunderContext object (accessed as `tsc` in the shell). Calling this method should make it so that all data loaded in the future will use the passed access keys to reach S3. These keys should be propagated out to child Data objects, and in general everything should Just Work. If this method is *not* called, then the current behavior should be maintained - the only reason one should have to use this new method is if you are in an environment where you don't have direct access to set configuration files or environment variables on worker nodes.