### PR TITLE
add setAWSCredentials method on ThunderContext

### DIFF
--- a/python/test/test_seriesloader.py
+++ b/python/test/test_seriesloader.py
@@ -323,7 +323,7 @@ class TestSeriesBinaryLoader(PySparkTestCaseWithOutputDir):
 class TestSeriesBinaryWriteFromStack(PySparkTestCaseWithOutputDir):
 
     def _run_roundtrip_tst(self, testCount, arrays, blockSize):
-        print "Running TestSeriesBinaryWriteFromStack roundtrip test #%d" % testCount
+        #  print "Running TestSeriesBinaryWriteFromStack roundtrip test #%d" % testCount
         inSubdir = os.path.join(self.outputdir, 'input%d' % testCount)
         os.mkdir(inSubdir)
 

--- a/python/thunder/factorization/nmf.py
+++ b/python/thunder/factorization/nmf.py
@@ -202,6 +202,7 @@ class NMF(object):
 
             # report results
             self.h = h
+            # TODO: need to propagate metadata through to this new Series object
             self.w = Series(w)
 
         else:

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -107,6 +107,13 @@ class Data(object):
         self._nrecords = None
         return self
 
+    def _checkOverwrite(self, outputDirPath):
+        """Checks for existence of outputDirPath, raising ValueError if it already exists
+        """
+        from thunder.utils.common import AWSCredentials, raiseErrorIfPathExists
+        awsCredentialOverride = AWSCredentials.fromContext(self.rdd.ctx)
+        raiseErrorIfPathExists(outputDirPath, awsCredentialsOverride=awsCredentialOverride)
+
     def first(self):
         """
         Return first record.

--- a/python/thunder/rdds/fileio/readers.py
+++ b/python/thunder/rdds/fileio/readers.py
@@ -30,6 +30,8 @@ import os
 import urllib
 import urlparse
 
+from thunder.utils.common import AWSCredentials
+
 _haveBoto = False
 try:
     import boto
@@ -122,7 +124,9 @@ def _localRead(filePath, startOffset=None, size=-1):
 class LocalFSParallelReader(object):
     """Parallel reader backed by python's native file() objects.
     """
-    def __init__(self, sparkContext):
+    def __init__(self, sparkContext, **kwargs):
+        # kwargs allow AWS credentials to be passed into generic Readers w/o exceptions being raised
+        # in this case kwargs are just ignored
         self.sc = sparkContext
         self.lastNRecs = None
 
@@ -272,23 +276,27 @@ class _BotoS3Client(object):
         else:
             return results
 
-    def __init__(self):
+    def __init__(self, awsCredentialsOverride=None):
         """Initialization; validates that AWS keys are available as environment variables.
 
         Will let boto library look up credentials itself according to its own rules - e.g. first looking for
         AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, then going through several possible config files and finally
         looking for a ~/.aws/credentials .ini-formatted file. See boto docs:
         http://boto.readthedocs.org/en/latest/boto_config_tut.html
+
+        However, if an AWSCredentials object is provided, its `awsAccessKeyId` and `awsSecretAccessKey` attributes
+        will be used instead of those found by the standard boto credential lookup process.
         """
         if not _haveBoto:
             raise ValueError("The boto package does not appear to be available; boto is required for BotoS3Reader")
+        self.awsCredentialsOverride = awsCredentialsOverride if awsCredentialsOverride else AWSCredentials()
 
 
 class BotoS3ParallelReader(_BotoS3Client):
     """Parallel reader backed by boto AWS client library.
     """
-    def __init__(self, sparkContext):
-        super(BotoS3ParallelReader, self).__init__()
+    def __init__(self, sparkContext, awsCredentialsOverride=None):
+        super(BotoS3ParallelReader, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self.sc = sparkContext
         self.lastNRecs = None
 
@@ -302,7 +310,7 @@ class BotoS3ParallelReader(_BotoS3Client):
             raise NotImplementedError("Recursive traversal of directories isn't yet implemented for S3 - sorry!")
         parse = _BotoS3Client.parseS3Query(dataPath)
 
-        conn = boto.connect_s3()
+        conn = boto.connect_s3(**self.awsCredentialsOverride.credentialsAsDict)
         bucket = conn.get_bucket(parse[0])
         keys = _BotoS3Client.retrieveKeys(bucket, parse[1], prefix=parse[2], postfix=parse[3])
         keyNameList = [key.name for key in keys]
@@ -326,8 +334,12 @@ class BotoS3ParallelReader(_BotoS3Client):
         if not keyNameList:
             raise FileNotFoundError("No S3 objects found for '%s'" % dataPath)
 
+        # try to prevent self from getting pulled into the closure
+        awsAccessKeyIdOverride_, awsSecretAccessKeyOverride_ = self.awsCredentialsOverride.credentials
+
         def readSplitFromS3(kvIter):
-            conn = boto.connect_s3()
+            conn = boto.connect_s3(aws_access_key_id=awsAccessKeyIdOverride_,
+                                   aws_secret_access_key=awsSecretAccessKeyOverride_)
             bucket = conn.get_bucket(bucketName)
             for kv in kvIter:
                 idx, keyName = kv
@@ -343,6 +355,10 @@ class BotoS3ParallelReader(_BotoS3Client):
 class LocalFSFileReader(object):
     """File reader backed by python's native file() objects.
     """
+    def __init__(self, **kwargs):
+        # do nothing; allows AWS access keys to be passed in to a generic Reader instance w/o blowing up
+        pass
+
     def __listRecursive(self, dataPath):
         if os.path.isdir(dataPath):
             dirname = dataPath
@@ -416,7 +432,7 @@ class BotoS3FileReader(_BotoS3Client):
     """
     def __getMatchingKeys(self, dataPath, filename=None):
         parse = _BotoS3Client.parseS3Query(dataPath)
-        conn = boto.connect_s3()
+        conn = boto.connect_s3(**self.awsCredentialsOverride.credentialsAsDict)
         bucketName = parse[0]
         keyName = parse[1]
         bucket = conn.get_bucket(bucketName)

--- a/python/thunder/rdds/fileio/seriesloader.py
+++ b/python/thunder/rdds/fileio/seriesloader.py
@@ -33,8 +33,14 @@ class SeriesLoader(object):
         minPartitions: int
             minimum number of partitions to use when loading data. (Used by fromText, fromMatLocal, and fromNpyLocal)
         """
+        from thunder.utils.common import AWSCredentials
         self.sc = sparkContext
         self.minPartitions = minPartitions
+        self.awsCredentialsOverride = AWSCredentials.fromContext(sparkContext)
+
+    def _checkOverwrite(self, outputDirPath):
+        from thunder.utils.common import raiseErrorIfPathExists
+        raiseErrorIfPathExists(outputDirPath, awsCredentialsOverride=self.awsCredentialsOverride)
 
     def fromArrays(self, arrays):
         """Create a Series object from a sequence of numpy ndarrays resident in memory on the driver.
@@ -125,8 +131,7 @@ class SeriesLoader(object):
     BinaryLoadParameters = namedtuple('BinaryLoadParameters', 'nkeys nvalues keytype valuetype')
     BinaryLoadParameters.__new__.__defaults__ = (None, None, 'int16', 'int16')
 
-    @staticmethod
-    def __loadParametersAndDefaults(dataPath, confFilename, nkeys, nvalues, keyType, valueType):
+    def __loadParametersAndDefaults(self, dataPath, confFilename, nkeys, nvalues, keyType, valueType):
         """Collects parameters to use for binary series loading.
 
         Priority order is as follows:
@@ -138,7 +143,7 @@ class SeriesLoader(object):
         -------
         BinaryLoadParameters instance
         """
-        params = SeriesLoader.loadConf(dataPath, confFilename=confFilename)
+        params = self.loadConf(dataPath, confFilename=confFilename)
 
         # filter dict to include only recognized field names:
         for k in params.keys():
@@ -274,7 +279,7 @@ class SeriesLoader(object):
         else:
             newDtype = str(newDtype)
 
-        reader = getFileReaderForPath(dataPath)()
+        reader = getFileReaderForPath(dataPath)(awsCredentialsOverride=self.awsCredentialsOverride)
         filenames = reader.list(dataPath, startIdx=startIdx, stopIdx=stopIdx, recursive=recursive)
         if not filenames:
             raise IOError("No files found for path '%s'" % dataPath)
@@ -388,7 +393,7 @@ class SeriesLoader(object):
         dataPath = self.__normalizeDatafilePattern(dataPath, ext)
         blockSize = parseMemoryString(blockSize)
 
-        reader = getFileReaderForPath(dataPath)()
+        reader = getFileReaderForPath(dataPath)(awsCredentialsOverride=self.awsCredentialsOverride)
         filenames = reader.list(dataPath, startIdx=startIdx, stopIdx=stopIdx, recursive=recursive)
         if not filenames:
             raise IOError("No files found for path '%s'" % dataPath)
@@ -431,6 +436,9 @@ class SeriesLoader(object):
         while blocksPerPlane * blocklenPixels < height * width:  # make sure we're reading the plane fully
             blocksPerPlane += 1
 
+        # prevent bringing in self in closure:
+        awsCredentialsOverride = self.awsCredentialsOverride
+
         # keys will be planeidx, blockidx:
         keys = list(itertools.product(xrange(npages), xrange(blocksPerPlane)))
 
@@ -441,7 +449,7 @@ class SeriesLoader(object):
             blockStart = None
             blockEnd = None
             for fname in filenames:
-                reader_ = getFileReaderForPath(fname)()
+                reader_ = getFileReaderForPath(fname)(awsCredentialsOverride=awsCredentialsOverride)
                 fp = reader_.open(fname)
                 try:
                     if doMinimizeReads:
@@ -584,13 +592,12 @@ class SeriesLoader(object):
         return Series(seriesBlocks, dims=Dimensions.fromTuple(dims[::-1]), dtype=dtype,
                       index=arange(npointsInSeries))
 
-    @staticmethod
-    def __saveSeriesRdd(seriesBlocks, outputDirPath, dims, npointsInSeries, dtype, overwrite=False):
+    def __saveSeriesRdd(self, seriesBlocks, outputDirPath, dims, npointsInSeries, dtype, overwrite=False):
         if not overwrite:
-            from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            self._checkOverwrite(outputDirPath)
             overwrite = True  # prevent additional downstream checks for this path
-        writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite)
+        writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite,
+                                                         awsCredentialsOverride=self.awsCredentialsOverride)
 
         def blockToBinarySeries(kvIter):
             label = None
@@ -607,7 +614,8 @@ class SeriesLoader(object):
             return [(label, val)]
 
         seriesBlocks.mapPartitions(blockToBinarySeries).foreach(writer.writerFcn)
-        writeSeriesConfig(outputDirPath, len(dims), npointsInSeries, valueType=dtype, overwrite=overwrite)
+        writeSeriesConfig(outputDirPath, len(dims), npointsInSeries, valueType=dtype, overwrite=overwrite,
+                          awsCredentialsOverride=self.awsCredentialsOverride)
 
     def saveFromStack(self, dataPath, outputDirPath, dims, ext="stack", blockSize="150M", dtype='int16',
                       newDtype=None, casting='safe', startIdx=None, stopIdx=None, overwrite=False, recursive=False):
@@ -652,8 +660,7 @@ class SeriesLoader(object):
 
         """
         if not overwrite:
-            from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            self._checkOverwrite(outputDirPath)
             overwrite = True  # prevent additional downstream checks for this path
 
         seriesBlocks, npointsInSeries, newDtype = \
@@ -661,7 +668,7 @@ class SeriesLoader(object):
                                            newDtype=newDtype, casting=casting, startIdx=startIdx, stopIdx=stopIdx,
                                            recursive=recursive)
 
-        SeriesLoader.__saveSeriesRdd(seriesBlocks, outputDirPath, dims, npointsInSeries, newDtype, overwrite=overwrite)
+        self.__saveSeriesRdd(seriesBlocks, outputDirPath, dims, npointsInSeries, newDtype, overwrite=overwrite)
 
     def saveFromTif(self, dataPath, outputDirPath, ext="tif", blockSize="150M",
                     newDtype=None, casting='safe', startIdx=None, stopIdx=None,
@@ -701,8 +708,7 @@ class SeriesLoader(object):
 
         """
         if not overwrite:
-            from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            self._checkOverwrite(outputDirPath)
             overwrite = True  # prevent additional downstream checks for this path
 
         seriesBlocks, metadata = self._getSeriesBlocksFromMultiTif(dataPath, ext=ext, blockSize=blockSize,
@@ -710,7 +716,7 @@ class SeriesLoader(object):
                                                                    startIdx=startIdx, stopIdx=stopIdx,
                                                                    recursive=recursive)
         dims, npointsInSeries, dtype = metadata
-        SeriesLoader.__saveSeriesRdd(seriesBlocks, outputDirPath, dims, npointsInSeries, dtype, overwrite=overwrite)
+        self.__saveSeriesRdd(seriesBlocks, outputDirPath, dims, npointsInSeries, dtype, overwrite=overwrite)
 
     def fromMatLocal(self, dataPath, varName, keyFile=None):
         """Loads Series data stored in a Matlab .mat file.
@@ -746,8 +752,7 @@ class SeriesLoader(object):
 
         return rdd
 
-    @staticmethod
-    def loadConf(dataPath, confFilename='conf.json'):
+    def loadConf(self, dataPath, confFilename='conf.json'):
         """Returns a dict loaded from a json file.
 
         Looks for file named `conffile` in same directory as `dataPath`
@@ -757,7 +762,7 @@ class SeriesLoader(object):
         if not confFilename:
             return {}
 
-        reader = getFileReaderForPath(dataPath)()
+        reader = getFileReaderForPath(dataPath)(awsCredentialsOverride=self.awsCredentialsOverride)
         try:
             jsonBuf = reader.read(dataPath, filename=confFilename)
         except FileNotFoundError:
@@ -774,7 +779,7 @@ class SeriesLoader(object):
 
 
 def writeSeriesConfig(outputDirPath, nkeys, nvalues, keyType='int16', valueType='int16',
-                      confFilename="conf.json", overwrite=True):
+                      confFilename="conf.json", overwrite=True, awsCredentialsOverride=None):
     """Helper function to write out a conf.json file with required information to load Series binary data.
     """
     import json
@@ -787,9 +792,11 @@ def writeSeriesConfig(outputDirPath, nkeys, nvalues, keyType='int16', valueType=
             'nkeys': nkeys, 'nvalues': nvalues,
             'valuetype': str(valueType), 'keytype': str(keyType)}
 
-    confWriter = filewriterClass(outputDirPath, confFilename, overwrite=overwrite)
+    confWriter = filewriterClass(outputDirPath, confFilename, overwrite=overwrite,
+                                 awsCredentialsOverride=awsCredentialsOverride)
     confWriter.writeFile(json.dumps(conf, indent=2))
 
     # touch "SUCCESS" file as final action
-    successWriter = filewriterClass(outputDirPath, "SUCCESS", overwrite=overwrite)
+    successWriter = filewriterClass(outputDirPath, "SUCCESS", overwrite=overwrite,
+                                    awsCredentialsOverride=awsCredentialsOverride)
     successWriter.writeFile('')

--- a/python/thunder/rdds/fileio/writers.py
+++ b/python/thunder/rdds/fileio/writers.py
@@ -39,7 +39,7 @@ except ImportError:
 
 
 class LocalFSParallelWriter(object):
-    def __init__(self, dataPath, overwrite=False):
+    def __init__(self, dataPath, overwrite=False, **kwargs):
         self._dataPath = dataPath
         # thanks stack overflow:
         # http://stackoverflow.com/questions/5977576/is-there-a-convenient-way-to-map-a-file-uri-to-os-path
@@ -68,9 +68,8 @@ class LocalFSParallelWriter(object):
 
 
 class _BotoS3Writer(_BotoS3Client):
-    def __init__(self):
-        super(_BotoS3Writer, self).__init__()
-
+    def __init__(self, awsCredentialsOverride=None):
+        super(_BotoS3Writer, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._contextActive = False
         self._conn = None
         self._keyName = None
@@ -81,7 +80,7 @@ class _BotoS3Writer(_BotoS3Client):
         Set up a boto s3 connection.
 
         """
-        conn = boto.connect_s3()
+        conn = boto.connect_s3(**self.awsCredentialsOverride.credentialsAsDict)
         parsed = _BotoS3Client.parseS3Query(dataPath)
         bucketName = parsed[0]
         keyName = parsed[1]
@@ -108,8 +107,8 @@ class _BotoS3Writer(_BotoS3Client):
 
 
 class BotoS3ParallelWriter(_BotoS3Writer):
-    def __init__(self, dataPath, overwrite=False):
-        super(BotoS3ParallelWriter, self).__init__()
+    def __init__(self, dataPath, overwrite=False, awsCredentialsOverride=None):
+        super(BotoS3ParallelWriter, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._dataPath = dataPath
         self._overwrite = overwrite
 
@@ -124,7 +123,7 @@ class BotoS3ParallelWriter(_BotoS3Writer):
 
 
 class LocalFSFileWriter(object):
-    def __init__(self, dataPath, filename, overwrite=False):
+    def __init__(self, dataPath, filename, overwrite=False, **kwargs):
         self._dataPath = dataPath
         self._filename = filename
         self._absPath = os.path.join(urllib.url2pathname(urlparse.urlparse(dataPath).path), filename)
@@ -148,8 +147,8 @@ class LocalFSFileWriter(object):
 
 
 class BotoS3FileWriter(_BotoS3Writer):
-    def __init__(self, dataPath, filename, overwrite=False):
-        super(BotoS3FileWriter, self).__init__()
+    def __init__(self, dataPath, filename, overwrite=False, awsCredentialsOverride=None):
+        super(BotoS3FileWriter, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._dataPath = dataPath
         self._filename = filename
         self._overwrite = overwrite
@@ -164,7 +163,7 @@ class BotoS3FileWriter(_BotoS3Writer):
 
 
 class LocalFSCollectedFileWriter(object):
-    def __init__(self, dataPath, overwrite=False):
+    def __init__(self, dataPath, overwrite=False, **kwargs):
         self._dataPath = dataPath
         self._absPath = urllib.url2pathname(urlparse.urlparse(dataPath).path)
         self._overwrite = overwrite
@@ -194,8 +193,8 @@ class LocalFSCollectedFileWriter(object):
 
 class BotoS3CollectedFileWriter(_BotoS3Writer):
     # todo: needs to check before writing if overwrite is True
-    def __init__(self, dataPath, overwrite=False):
-        super(BotoS3CollectedFileWriter, self).__init__()
+    def __init__(self, dataPath, overwrite=False, awsCredentialsOverride=None):
+        super(BotoS3CollectedFileWriter, self).__init__(awsCredentialsOverride=awsCredentialsOverride)
         self._dataPath = dataPath
         self._overwrite = overwrite
 

--- a/python/thunder/rdds/imgblocks/blocks.py
+++ b/python/thunder/rdds/imgblocks/blocks.py
@@ -110,19 +110,21 @@ class Blocks(Data):
         """
         from thunder.rdds.fileio.writers import getParallelWriterForPath
         from thunder.rdds.fileio.seriesloader import writeSeriesConfig
+        from thunder.utils.common import AWSCredentials
 
         if not overwrite:
-            from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputDirPath)
+            self._checkOverwrite(outputDirPath)
             overwrite = True  # prevent additional downstream checks for this path
 
-        writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite)
+        awsCredentialsOverride = AWSCredentials.fromContext(self.rdd.ctx)
+        writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite,
+                                                         awsCredentialsOverride=awsCredentialsOverride)
 
         binseriesRdd = self.toBinarySeries()
 
         binseriesRdd.foreach(writer.writerFcn)
         writeSeriesConfig(outputDirPath, len(self.dims), self.nimages, keyType='int16', valueType=self.dtype,
-                          overwrite=overwrite)
+                          overwrite=overwrite, awsCredentialsOverride=awsCredentialsOverride)
 
 
 class SimpleBlocks(Blocks):

--- a/python/thunder/rdds/matrices.py
+++ b/python/thunder/rdds/matrices.py
@@ -4,7 +4,6 @@ Class with utilities for representing and working with matrices
 from numpy import dot, outer, shape, ndarray, add, subtract, multiply, zeros, divide, arange
 
 from thunder.rdds.series import Series
-from thunder.rdds.data import Data
 
 
 # TODO: right divide and left divide

--- a/python/thunder/rdds/series.py
+++ b/python/thunder/rdds/series.py
@@ -792,7 +792,7 @@ class Series(Data):
         simpleBlocksRdd = groupedRdd.map(blockingStrategy.combiningFunction)
         return returnType(simpleBlocksRdd, dims=self.dims, nimages=len(self.index), dtype=self.dtype)
 
-    def saveAsBinarySeries(self, outputdirname, overwrite=False):
+    def saveAsBinarySeries(self, outputDirPath, overwrite=False):
         """Writes out Series-formatted data.
 
         This method (Series.saveAsBinarySeries) writes out binary series files using the current partitioning
@@ -808,7 +808,7 @@ class Series(Data):
 
         Parameters
         ----------
-        outputdirname : string path or URI to directory to be created
+        outputDirPath : string path or URI to directory to be created
             Output files will be written underneath outputdirname. This directory must not yet exist
             (unless overwrite is True), and must be no more than one level beneath an existing directory.
             It will be created as a result of this call.
@@ -822,10 +822,10 @@ class Series(Data):
         from thunder.rdds.imgblocks.blocks import SimpleBlocks
         from thunder.rdds.fileio.writers import getParallelWriterForPath
         from thunder.rdds.fileio.seriesloader import writeSeriesConfig
+        from thunder.utils.common import AWSCredentials
 
         if not overwrite:
-            from thunder.utils.common import raiseErrorIfPathExists
-            raiseErrorIfPathExists(outputdirname)
+            self._checkOverwrite(outputDirPath)
             overwrite = True  # prevent additional downstream checks for this path
 
         def partitionToBinarySeries(kvIter):
@@ -850,7 +850,9 @@ class Series(Data):
                 label = SimpleBlocks.getBinarySeriesNameForKey(firstKey) + ".bin"
                 return iter([(label, val)])
 
-        writer = getParallelWriterForPath(outputdirname)(outputdirname, overwrite=overwrite)
+        awsCredentials = AWSCredentials.fromContext(self.rdd.ctx)
+        writer = getParallelWriterForPath(outputDirPath)(outputDirPath, overwrite=overwrite,
+                                                         awsCredentialsOverride=awsCredentials)
 
         binseriesrdd = self.rdd.mapPartitions(partitionToBinarySeries)
 
@@ -859,8 +861,8 @@ class Series(Data):
         # TODO: all we really need here are the number of keys and number of values, which could in principle
         # be cached in _nkeys and _nvals attributes, removing the need for this .first() call in most cases.
         firstKey, firstVal = self.first()
-        writeSeriesConfig(outputdirname, len(firstKey), len(firstVal), keyType='int16', valueType=self.dtype,
-                          overwrite=overwrite)
+        writeSeriesConfig(outputDirPath, len(firstKey), len(firstVal), keyType='int16', valueType=self.dtype,
+                          overwrite=overwrite, awsCredentialsOverride=awsCredentials)
 
     def toRowMatrix(self):
         """

--- a/python/thunder/utils/common.py
+++ b/python/thunder/utils/common.py
@@ -177,7 +177,7 @@ def parseMemoryString(memStr):
         return int(memStr)
 
 
-def raiseErrorIfPathExists(path):
+def raiseErrorIfPathExists(path, awsCredentialsOverride=None):
     """Raises a ValueError if the passed path string is found to already exist.
 
     The ValueError message will suggest calling with overwrite=True; this function is expected to be
@@ -185,8 +185,47 @@ def raiseErrorIfPathExists(path):
     """
     # check that specified output path does not already exist
     from thunder.rdds.fileio.readers import getFileReaderForPath
-    reader = getFileReaderForPath(path)()
+    reader = getFileReaderForPath(path)(awsCredentialsOverride=awsCredentialsOverride)
     existing = reader.list(path, includeDirectories=True)
     if existing:
         raise ValueError("Path %s appears to already exist. Specify a new directory, or call " % path +
                          "with overwrite=True to overwrite.")
+
+
+class AWSCredentials(object):
+    __slots__ = ('awsAccessKeyId', 'awsSecretAccessKey')
+
+    def __init__(self, awsAccessKeyId=None, awsSecretAccessKey=None):
+        self.awsAccessKeyId = awsAccessKeyId if awsAccessKeyId else None
+        self.awsSecretAccessKey = awsSecretAccessKey if awsSecretAccessKey else None
+
+    def __repr__(self):
+        def obfuscate(s):
+            return "None" if s is None else "<%d-char string>" % len(s)
+        return "AWSCredentials(accessKeyId: %s, secretAccessKey: %s)" % \
+               (obfuscate(self.awsAccessKeyId), obfuscate(self.awsSecretAccessKey))
+
+    def setOnContext(self, sparkContext):
+        sparkContext._jsc.hadoopConfiguration().set("fs.s3n.awsAccessKeyId", self.awsAccessKeyId)
+        sparkContext._jsc.hadoopConfiguration().set("fs.s3n.awsSecretAccessKey", self.awsSecretAccessKey)
+
+    @classmethod
+    def fromContext(cls, sparkContext):
+        if sparkContext:
+            awsAccessKeyId = sparkContext._jsc.hadoopConfiguration().get("fs.s3n.awsAccessKeyId", "")
+            awsSecretAccessKey = sparkContext._jsc.hadoopConfiguration().get("fs.s3n.awsSecretAccessKey", "")
+            return AWSCredentials(awsAccessKeyId, awsSecretAccessKey)
+        else:
+            return AWSCredentials()
+
+    @property
+    def credentials(self):
+        if self.awsAccessKeyId and self.awsSecretAccessKey:
+            return self.awsAccessKeyId, self.awsSecretAccessKey
+        else:
+            return None, None
+
+    @property
+    def credentialsAsDict(self):
+        access, secret = self.credentials
+        return {"aws_access_key_id": access, "aws_secret_access_key": secret}


### PR DESCRIPTION
This is a revision of PR #114, with a single squashed commit replacing the series of commits on that PR. This PR has also been revised since the previous to remove the `awsCredentials` attribute from `Data` objects, as discussed. The original comment from PR #114 is below, with a comment about propagating these settings to child Data objects removed.

-----

AWS credentials are required to access S3. Typically these credentials end up in two locations - first, they're put in a `core-site.xml` file, where they're read out and used by the Hadoop InputFormat readers, which in Thunder primarily come in when reading binary Series data. For other access to S3, we use the `boto` module, which looks for credentials in a couple different places, including environment variables and a `.boto` config file. In the `thunder-ec2` script we write out these credentials to a `.boto` file and push this file out to all workers.

So far so good. The problem comes in when running in managed environments that don't give direct access to the cluster node file systems, such as the new Databricks Cloud. Here we can push out credentials to be used by the Hadoop readers by something like the following:
```python
sc._jsc.hadoopConfiguration().set("fs.s3n.awsAccessKeyId", ACCESS_KEY)
sc._jsc.hadoopConfiguration().set("fs.s3n.awsSecretAccessKey", SECRET_KEY)
```
But we don't have a good solution (or any solution, really) for getting the AWS credentials out where they can be used by boto on the workers. So, at the moment, on Databricks Cloud most attempts to access S3 fail once a worker node attempts to connect and discovers that it doesn't have the AWS credentials.

The "solution" implemented in this PR is to add a new `setAWSCredentials` method on the ThunderContext object (accessed as `tsc` in the shell). Calling this method should make it so that all data loaded in the future will use the passed access keys to reach S3. If this method is *not* called, then the current behavior should be maintained - the only reason one should have to use this new method is if you are in an environment where you don't have direct access to set configuration files or environment variables on worker nodes.