### PR TITLE
Casting scalars

### DIFF
--- a/python/test/test_data.py
+++ b/python/test/test_data.py
@@ -296,15 +296,10 @@ class TestCasting(PySparkTestCase):
             else:
                 # the unsafe cast will return *something*, but we don't have any expectations as to what:
                 assert_is_not_none(downcasted)
-            if can_cast(origVal, 'float16', casting="safe"):
-                # numpy scalars might be safely downcastable, depending on value
-                # numpy arrays are assumed not to be safely downcastable, no value check is performed by can_cast
-                assert_true(allclose(origVal, data.astype('float16', casting="safe").first()[1], rtol=1e-03))
-            else:
-                # raises py4j.protocol.Py4JJavaError after a TypeError on workers:
-                # we're not importing py4j, and it seems like overkill to do so just for this one assertion,
-                # so just assert an Exception.
-                assert_raises(Exception, data.astype('float16', casting="safe").first)
+            # raises py4j.protocol.Py4JJavaError after a TypeError on workers:
+            # we're not importing py4j, and it seems like overkill to do so just for this one assertion,
+            # so just assert an Exception.
+            assert_raises(Exception, data.astype('float16', casting="safe").first)
 
 
 class TestDataMethods(PySparkTestCase):

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -313,7 +313,7 @@ class Data(object):
         """
         if dtype is None or dtype == '':
             return self
-        from numpy import can_cast, ndarray
+        from numpy import ndarray
         from numpy import dtype as dtypeFunc
         if dtype == 'smallfloat':
             # get the smallest floating point type that can be safely cast to from our current type
@@ -323,17 +323,10 @@ class Data(object):
         def cast(v, dtype_, casting_):
             if isinstance(v, ndarray):
                 return v.astype(dtype_, casting=casting_, copy=False)
-            elif can_cast(v, dtype_, casting=casting_):
-                if hasattr(v, 'astype'):
-                    # numpy scalars have an 'astype' method, but don't have the "casting" kwarg:
-                    return v.astype(dtype_)
-                else:
-                    # turn ourself into a numpy scalar of the appropriate type
-                    # despite the name, 'asarray' will return a scalar if a scalar is passed
-                    return asarray(v, dtype=dtype_)
             else:
-                raise TypeError("Cannot cast value '%s' to dtype '%s' according to the rule '%s'" %
-                                (str(v), str(dtype_), casting_))
+                # assume we are a scalar, either a numpy scalar or a python scalar
+                # turn ourself into a numpy scalar of the appropriate type
+                return asarray([v]).astype(dtype_, casting=casting_, copy=False)[0]
 
         nextRdd = self.rdd.mapValues(lambda v: cast(v, dtypeFunc(dtype), casting))
         return self._constructor(nextRdd, dtype=str(dtype)).__finalize__(self)

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -313,12 +313,29 @@ class Data(object):
         """
         if dtype is None or dtype == '':
             return self
+        from numpy import can_cast, ndarray
+        from numpy import dtype as dtypeFunc
         if dtype == 'smallfloat':
             # get the smallest floating point type that can be safely cast to from our current type
             from thunder.utils.common import smallestFloatType
             dtype = smallestFloatType(self.dtype)
 
-        nextRdd = self.rdd.mapValues(lambda v: v.astype(dtype, casting=casting, copy=False))
+        def cast(v, dtype_, casting_):
+            if isinstance(v, ndarray):
+                return v.astype(dtype_, casting=casting_, copy=False)
+            elif can_cast(v, dtype_, casting=casting_):
+                if hasattr(v, 'astype'):
+                    # numpy scalars have an 'astype' method, but don't have the "casting" kwarg:
+                    return v.astype(dtype_)
+                else:
+                    # turn ourself into a numpy scalar of the appropriate type
+                    # despite the name, 'asarray' will return a scalar if a scalar is passed
+                    return asarray(v, dtype=dtype_)
+            else:
+                raise TypeError("Cannot cast value '%s' to dtype '%s' according to the rule '%s'" %
+                                (str(v), str(dtype_), casting_))
+
+        nextRdd = self.rdd.mapValues(lambda v: cast(v, dtypeFunc(dtype), casting))
         return self._constructor(nextRdd, dtype=str(dtype)).__finalize__(self)
 
     def apply(self, func, keepDtype=False, keepIndex=False):


### PR DESCRIPTION
This PR adds support for numpy and python scalars as values of Data records in `Data.astype()`. Fixes #121.