### PR TITLE
support JSON configuration file in Images loading

### DIFF
--- a/python/test/test_imagesloader.py
+++ b/python/test/test_imagesloader.py
@@ -1,3 +1,4 @@
+import json
 from numpy import arange, array_equal, ndarray
 from numpy import dtype as dtypeFunc
 import os
@@ -202,6 +203,30 @@ class TestImagesLoaderUsingOutputDir(PySparkTestCaseWithOutputDir):
         ary2.tofile(filename)
 
         image = ImagesLoader(self.sc).fromStack(self.outputdir, dims=(4, 2))
+
+        collectedImage = image.collect()
+        assert_equals(2, len(collectedImage))
+        assert_equals(0, collectedImage[0][0])  # check key
+        assert_equals(image.dims.count, collectedImage[0][1].shape)
+        assert_true(array_equal(ary.T, collectedImage[0][1]))  # check value
+        assert_equals(1, collectedImage[1][0])  # check image 2
+        assert_true(array_equal(ary2.T, collectedImage[1][1]))
+
+    def test_fromStacksWithConf(self):
+        ary = arange(8, dtype=dtypeFunc('int32')).reshape((2, 4))
+        ary2 = arange(8, 16, dtype=dtypeFunc('int32')).reshape((2, 4))
+        filename = os.path.join(self.outputdir, "test01.bin")
+        ary.tofile(filename)
+        filename = os.path.join(self.outputdir, "test02.bin")
+        ary2.tofile(filename)
+        conf = {"dims": (4, 2), "dtype": "int32", "ext": "bin"}
+        with open(os.path.join(self.outputdir, "conf.json"), 'w') as fp:
+            json.dump(conf, fp)
+
+        image = ImagesLoader(self.sc).fromStack(self.outputdir)
+        assert_equals("int32", image._dtype)
+        assert_equals(2, image._nrecords)
+        assert_equals((4, 2), image._dims.count)
 
         collectedImage = image.collect()
         assert_equals(2, len(collectedImage))


### PR DESCRIPTION
This PR adds support for an optional JSON configuration file to specify parameters when loading Images data, resolving #108.

This is roughly analogous to the existing support for a `conf.json` file when loading Series binary files, which has been in place for a while. I haven't made any effort in this PR to merge the two, but that would be I think a relatively simple and useful refactoring.

The parameters that are supported inside of conf.json are those that refer to the images and image files themselves (e.g. `dims`, `dtype`, `ext`, `recursive`, `nplanes`) and not parameters that refer to how they are to be converted to a Series (not `blockSize`, `renumber`, etc). This distinction is pretty clear in my mind, but I admit it might not be so obvious to a casual user.