### PR TITLE
Conda on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ install:
   # Setup miniconda
   - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose numpy scipy scikit-learn scikit-image matplotlib
   - source activate test-environment
-  - python python/setup.py install
+  - cd python
+  - python setup.py install
+  - cd ..
   # Install Spark
   - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.1.0-bin-hadoop1.tgz
   - tar -xzf spark-1.1.0-bin-hadoop1.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   # Setup miniconda
   - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose numpy scipy scikit-learn scikit-image matplotlib
   - source activate test-environment
-  - python setup.py install
+  - python python/setup.py install
   # Install Spark
   - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.1.0-bin-hadoop1.tgz
   - tar -xzf spark-1.1.0-bin-hadoop1.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 
 install:
   # Setup miniconda
-  - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+  - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION argparse numpy scipy scikit-learn scikit-image matplotlib nose rednose zope.cachedescriptors
   - source activate test-environment
   # Install Spark
   - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.1.0-bin-hadoop1.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+  - "2.6"
   - "2.7"
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,41 @@
 language: python
+
 python:
   - "2.7"
+
 jdk:
   - openjdk7
+
 virtualenv:
   system_site_packages: true
+
+before_install:
+  # install miniconda
+  - sudo apt-get update
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.7.3-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+
 install:
+  # Setup miniconda
+  - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+  - source activate test-environment
   # Install Spark
   - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.1.0-bin-hadoop1.tgz
   - tar -xzf spark-1.1.0-bin-hadoop1.tgz
-  - sudo apt-get install -qq python-numpy python-scipy python-sklearn
-  - pip install -r python/requirements.txt
   # Workaround for Travis issue with POSIX semaphores; see
   # https://github.com/travis-ci/travis-cookbooks/issues/155
   - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
+
 script:
     - export SPARK_HOME=`pwd`/spark-1.1.0-bin-hadoop1
     - cd python/test
-    - ./run_tests.sh -v --verbosity=2
+    - ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ before_install:
 
 install:
   # Setup miniconda
-  - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION argparse numpy scipy scikit-learn scikit-image matplotlib nose rednose zope.cachedescriptors
+  - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION argparse nose numpy scipy scikit-learn scikit-image matplotlib
   - source activate test-environment
+  - python setup.py install
   # Install Spark
   - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.1.0-bin-hadoop1.tgz
   - tar -xzf spark-1.1.0-bin-hadoop1.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
 jdk:
   - openjdk7
 
-virtualenv:
-  system_site_packages: true
-
 before_install:
   # install miniconda
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 
 install:
   # Setup miniconda
-  - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION argparse nose numpy scipy scikit-learn scikit-image matplotlib
+  - conda create --yes -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose numpy scipy scikit-learn scikit-image matplotlib
   - source activate test-environment
   - python setup.py install
   # Install Spark


### PR DESCRIPTION
This PR changes our Travis build to use Miniconda, a light-weight installation of Anaconda, which will make it easier to maintain recent versions of scientific libraries on our Travis builds, and matches the environment in which many users use Thunder fairly well.

Fixes #138 