### PR TITLE
Anaconda on EC2

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn
 matplotlib
 nose
 rednose
+termcolor


### PR DESCRIPTION
This PR modifies the Thunder EC2 scripts to install Anaconda. Based on discussions with @broxtronix and an earlier PR from @npyoung, this appears to be the most straigtforward way to get a newer version of Python (2.7) and more up-to-date scientific packages (newer versions of numpy, scipy, scikit-learn, and libraries that require 2.7, like seaborn) on our EC2 clusters. This also makes the EC2 installation better matched to our Travis builds (which now also use Anaconda).

We also added features for supressing the excessive output in earlier versions of the scripts, and giving simpler and cleaner indications of progress:

![image](https://cloud.githubusercontent.com/assets/3387500/6883632/a86355ba-d573-11e4-8af0-1dde257c36de.png)

This did require adding one minor dependency (termcolor).

I've tested this script by launching small EC2 clusters and loading example data in Thunder, using both Spark 1.2 and 1.3. I also tested stopping and then starting a cluster again.

Launch times should be comparable to those obtained previously.

NOTE: If you are currently running a Spark EC2 cluster launched using an earlier version of this script, it may not work to call `stop` and then `start` on it once this patch is merged (at least, I have not tested this). After this change, the safest thing would be to launch a new cluster.