### PR TITLE
updated documentation in data.py, svd.py, ica.py, and pca.py and fixed some typos

### DIFF
--- a/python/thunder/factorization/ica.py
+++ b/python/thunder/factorization/ica.py
@@ -22,8 +22,10 @@ class ICA(object):
         Number of independent components to estimate
 
     svdMethod : string, optional, default = "auto"
-        Which SVD method to use. If set to 'auto',
-        will select preferred method based on dimensionality.
+        Which SVD method to use.
+        If set to 'direct', will compute the SVD directly.
+        If set to 'em', will approximate the SVD using iterative expectation-maximization algorithm.
+        If set to 'auto', will select preferred method based on dimensionality of input data.
 
     maxIter : Int, optional, default = 10
         Maximum number of iterations
@@ -42,6 +44,10 @@ class ICA(object):
     `sigs` : RowMatrix, nrows, each array of shape (c,)
         Estimated independent components
 
+    See also
+    --------
+    SVD : singular value decomposition
+    PCA: principal components analysis
     """
 
     def __init__(self, c, k=None, svdMethod='auto', maxIter=10, tol=0.000001, seed=0):

--- a/python/thunder/factorization/ica.py
+++ b/python/thunder/factorization/ica.py
@@ -23,9 +23,9 @@ class ICA(object):
 
     svdMethod : string, optional, default = "auto"
         Which SVD method to use.
-        If set to 'direct', will compute the SVD directly.
+        If set to 'direct', will compute the SVD with direct gramian matrix estimation and eigenvector decomposition.
         If set to 'em', will approximate the SVD using iterative expectation-maximization algorithm.
-        If set to 'auto', will select preferred method based on dimensionality of input data.
+        If set to 'auto', will use 'em' if number of columns in input data exceeds 750, otherwise will use 'direct'.
 
     maxIter : Int, optional, default = 10
         Maximum number of iterations

--- a/python/thunder/factorization/pca.py
+++ b/python/thunder/factorization/pca.py
@@ -18,7 +18,7 @@ class PCA(object):
 
     svdMethod : str, optional, default = "auto"
         Which method to use for performing the SVD. If set to 'auto',
-        will select preferred method based on dimensionality.
+        will select preferred method based on dimensionality of input data.
 
     Attributes
     ----------

--- a/python/thunder/factorization/pca.py
+++ b/python/thunder/factorization/pca.py
@@ -17,8 +17,9 @@ class PCA(object):
         Number of principal components to estimate
 
     svdMethod : str, optional, default = "auto"
-        Which method to use for performing the SVD. If set to 'auto',
-        will select preferred method based on dimensionality of input data.
+        If set to 'direct', will compute the SVD with direct gramian matrix estimation and eigenvector decomposition.
+        If set to 'em', will approximate the SVD using iterative expectation-maximization algorithm.
+        If set to 'auto', will use 'em' if number of columns in input data exceeds 750, otherwise will use 'direct'.
 
     Attributes
     ----------

--- a/python/thunder/factorization/svd.py
+++ b/python/thunder/factorization/svd.py
@@ -11,7 +11,7 @@ from thunder.rdds.matrices import RowMatrix
 
 class SVD(object):
     """
-    Singular value decomposiiton on a distributed matrix.
+    Singular value decomposition on a distributed matrix.
 
     Parameters
     ----------
@@ -19,8 +19,10 @@ class SVD(object):
         Number of singular vectors to estimate
 
     method : string, optional, default = "auto"
-        Whether to use a direct or iterative method. If set to 'auto',
-        will select preferred method based on dimensionality.
+        Whether to use a direct or iterative method.
+        If set to 'direct', will compute the SVD directly.
+        If set to 'em', will approximate the SVD using iterative expectation-maximization algorithm.
+        If set to 'auto', will select preferred method based on dimensionality.
 
     maxIter : int, optional, default = 20
         Maximum number of iterations if using an iterative method

--- a/python/thunder/factorization/svd.py
+++ b/python/thunder/factorization/svd.py
@@ -20,9 +20,11 @@ class SVD(object):
 
     method : string, optional, default = "auto"
         Whether to use a direct or iterative method.
-        If set to 'direct', will compute the SVD directly.
+        If set to 'direct', will compute the SVD with direct gramian matrix estimation and eigenvector decomposition.
         If set to 'em', will approximate the SVD using iterative expectation-maximization algorithm.
-        If set to 'auto', will select preferred method based on dimensionality.
+        If set to 'auto', will use 'em' if number of columns in input data exceeds 750, otherwise will use 'direct'.
+
+
 
     maxIter : int, optional, default = 20
         Maximum number of iterations if using an iterative method

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -459,7 +459,8 @@ class Data(object):
 
     def mean(self, dtype='float64', casting='safe'):
         """
-        Mean of values across keys, returned as an ndarray.
+        Mean of values computed by aggregating across records, returned as an ndarray
+        with the same size as a single record.
 
         If dtype is not None, then the values will first be cast to the requested
         type before the operation is performed. See Data.astype() for details.
@@ -468,7 +469,8 @@ class Data(object):
 
     def sum(self, dtype='float64', casting='safe'):
         """
-        Sum of values across keys, returned as an ndarray.
+        Sum of values computed by aggregating across records, returned as an ndarray
+        with the same size as a single record.
 
         If dtype is not None, then the values will first be cast to the requested type before the operation is
         performed. See Data.astype() for details.
@@ -480,7 +482,8 @@ class Data(object):
 
     def variance(self, dtype='float64', casting='safe'):
         """
-        Variance of values across keys, returned as an ndarray.
+        Variance of values computed by aggregating across records, returned as an ndarray
+        with the same size as a single record.
 
         If dtype is not None, then the values will first be cast to the requested type before the operation is
         performed. See Data.astype() for details.
@@ -489,7 +492,8 @@ class Data(object):
 
     def stdev(self, dtype='float64', casting='safe'):
         """
-        Standard deviation of values across keys, returned as an ndarray.
+        Standard deviation of values computed by aggregating across records, returned as an ndarray
+        with the same size as a single record.
 
         If dtype is not None, then the values will first be cast to the requested type before the operation is
         performed. See Data.astype() for details.

--- a/python/thunder/rdds/data.py
+++ b/python/thunder/rdds/data.py
@@ -459,7 +459,7 @@ class Data(object):
 
     def mean(self, dtype='float64', casting='safe'):
         """
-        Mean of values, ignoring keys
+        Mean of values across keys, returned as an ndarray.
 
         If dtype is not None, then the values will first be cast to the requested
         type before the operation is performed. See Data.astype() for details.
@@ -468,7 +468,7 @@ class Data(object):
 
     def sum(self, dtype='float64', casting='safe'):
         """
-        Sum of values, ignoring keys
+        Sum of values across keys, returned as an ndarray.
 
         If dtype is not None, then the values will first be cast to the requested type before the operation is
         performed. See Data.astype() for details.
@@ -480,7 +480,7 @@ class Data(object):
 
     def variance(self, dtype='float64', casting='safe'):
         """
-        Variance of values, ignoring keys
+        Variance of values across keys, returned as an ndarray.
 
         If dtype is not None, then the values will first be cast to the requested type before the operation is
         performed. See Data.astype() for details.
@@ -489,7 +489,7 @@ class Data(object):
 
     def stdev(self, dtype='float64', casting='safe'):
         """
-        Standard deviation of values, ignoring keys
+        Standard deviation of values across keys, returned as an ndarray.
 
         If dtype is not None, then the values will first be cast to the requested type before the operation is
         performed. See Data.astype() for details.
@@ -525,12 +525,12 @@ class Data(object):
         return out.values().mapPartitions(lambda i: [StatCounter(i, stats=requestedStats)]).reduce(redFunc)
 
     def max(self):
-        """ Maximum of values, ignoring keys """
+        """ Maximum of values across keys, returned as an ndarray. """
         # NOTE: Does not use stats('max') to prevent cast to float64
         return self.rdd.values().reduce(maximum)
 
     def min(self):
-        """ Minimum of values, ignoring keys """
+        """ Minimum of values across keys, returned as an ndarray. """
         # NOTE: Does not use stats('min') to prevent cast to float64
         return self.rdd.values().reduce(minimum)
 
@@ -577,7 +577,7 @@ class Data(object):
 
     def filter(self, func):
         """
-        Filter records by appliyng a function to each record.
+        Filter records by applying a function to each record.
 
         This calls the Spark filter() method on the underlying RDD.
         """


### PR DESCRIPTION
This PR attempts to clarify the documentation in the factorization classes `thunder.factorization.ica`, `thunder.factorization.pca`, and `thunder.factorization.svd` by adding text in the docstrings for these functions that detail the different options for the kwarg `svdMethod`. 

This PR also attempts to clarify the documentation for statistical methods on the `data` class, e.g., `data.mean()`, by indicating in their docstrings that these methods are computed over keys and that output is returned as an ndarray.

I also fixed a few small typos.

