### PR TITLE
Image-based local correlation

### DIFF
--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -650,7 +650,7 @@ class TestImagesLocalCorr(PySparkTestCase):
 
         corr = self.get_local_corr(dataLocal, 1)
 
-        assert(allclose(corr[4][1], truth))
+        assert(allclose(corr[1][1], truth))
 
     def test_localCorr_0Indexing_3D(self):
 
@@ -673,12 +673,9 @@ class TestImagesLocalCorr(PySparkTestCase):
 
         corr = self.get_local_corr(dataLocal, 1)
 
-        assert(allclose(corr[4][1], truth))
+        assert(allclose(corr[1][1], truth))
 
     def test_localCorr_Images_2D(self):
-        """
-        Test the localCorr without converting from Series to Images (using self.get_local_corr) first.
-        """
 
         dataLocal = [
             (0, array([[1.0, 2.0, 9.0], [5.0, 4.0, 5.0], [4.0, 6.0, 0.0]])),
@@ -694,14 +691,9 @@ class TestImagesLocalCorr(PySparkTestCase):
 
         corr = self.get_local_corr(dataLocal, 1, images=True)
 
-        assert(allclose(corr[4][1], truth))
+        assert(allclose(corr[1][1], truth))
 
     def test_localCorr_Images_3D(self):
-        """
-        Test the localCorr without converting from Series to Images (using self.get_local_corr) first.
-        """
-
-        #TODO
 
         dataLocal = [
             (0, array([[1.0, 2.0, 9.0], [5.0, 4.0, 5.0], [4.0, 6.0, 0.0]])),
@@ -717,7 +709,7 @@ class TestImagesLocalCorr(PySparkTestCase):
 
         corr = self.get_local_corr(dataLocal, 1, images=True)
 
-        assert(allclose(corr[4][1], truth))
+        assert(allclose(corr[1][1], truth))
 
 
 class TestImagesUsingOutputDir(PySparkTestCaseWithOutputDir):

--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -1,7 +1,7 @@
 import glob
 import struct
 import os
-from numpy import allclose, arange, array, array_equal, prod, squeeze, zeros
+from numpy import allclose, arange, array, array_equal, prod, squeeze, zeros, mean, corrcoef
 from numpy import dtype as dtypeFunc
 import itertools
 from nose.tools import assert_equals, assert_raises, assert_true
@@ -612,6 +612,67 @@ class TestImagesMeanByRegions(PySparkTestCase):
         # check values
         assert_equals(5, collected[0][1][0])
         assert_equals(15, collected[1][1][0])
+
+class TestImagesLocalCorr(PySparkTestCase):
+    """Test accuracy for local correlation
+    by comparison to known result
+    (verified by directly computing
+    result with numpy's mean and corrcoef)
+
+    Test with indexing from both 0 and 1,
+    and for both 2D and 3D data
+    """
+
+    def get_local_corr(self, data, neighborhood):
+        ser = Series(self.sc.parallelize(data))
+        imgs = ser.toImages()
+        return imgs.localCorr(neighborhood=neighborhood)
+
+    def test_localCorr_0Indexing_2D(self):
+
+        dataLocal = [
+            ((0, 0), array([1.0, 2.0, 3.0])),
+            ((0, 1), array([2.0, 2.0, 4.0])),
+            ((0, 2), array([9.0, 2.0, 1.0])),
+            ((1, 0), array([5.0, 2.0, 5.0])),
+            ((2, 0), array([4.0, 2.0, 6.0])),
+            ((1, 1), array([4.0, 2.0, 8.0])),
+            ((1, 2), array([5.0, 4.0, 1.0])),
+            ((2, 1), array([6.0, 3.0, 2.0])),
+            ((2, 2), array([0.0, 2.0, 1.0]))
+        ]
+
+        # get ground truth by correlating mean with the center
+        ts = map(lambda x: x[1], dataLocal)
+        mn = mean(ts, axis=0)
+        truth = corrcoef(mn, array([4.0, 2.0, 8.0]))[0, 1]
+
+        corr = self.get_local_corr(dataLocal, 1)
+
+        assert(allclose(corr.collect()[4][1], truth))
+
+    def test_localCorr_0Indexing_3D(self):
+
+        dataLocal = [
+            ((0, 0, 0), array([1.0, 2.0, 3.0])),
+            ((0, 1, 0), array([2.0, 2.0, 4.0])),
+            ((0, 2, 0), array([9.0, 2.0, 1.0])),
+            ((1, 0, 0), array([5.0, 2.0, 5.0])),
+            ((2, 0, 0), array([4.0, 2.0, 6.0])),
+            ((1, 1, 0), array([4.0, 2.0, 8.0])),
+            ((1, 2, 0), array([5.0, 4.0, 1.0])),
+            ((2, 1, 0), array([6.0, 3.0, 2.0])),
+            ((2, 2, 0), array([0.0, 2.0, 1.0]))
+        ]
+
+        # get ground truth by correlating mean with the center
+        ts = map(lambda x: x[1], dataLocal)
+        mn = mean(ts, axis=0)
+        truth = corrcoef(mn, array([4.0, 2.0, 8.0]))[0, 1]
+
+        corr = self.get_local_corr(dataLocal, 1)
+
+        assert(allclose(corr.collect()[4][1], truth))
 
 
 class TestImagesUsingOutputDir(PySparkTestCaseWithOutputDir):

--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -384,6 +384,11 @@ class TestImagesMethods(PySparkTestCase):
         from thunder.rdds.images import Images
         self._run_tst_filter(Images.medianFilter, median_filter)
 
+    def test_uniformFilter3d(self):
+        from scipy.ndimage.filters import uniform_filter
+        from thunder.rdds.images import Images
+        self._run_tst_filter(Images.uniformFilter, uniform_filter)
+
     def _run_tst_crop(self, minBounds, maxBounds):
         dims = (2, 2, 4)
         sz = reduce(lambda x, y: x*y, dims)

--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -1,7 +1,7 @@
 import glob
 import struct
 import os
-from numpy import allclose, arange, array, array_equal, prod, squeeze, zeros, size
+from numpy import allclose, arange, array, array_equal, prod, squeeze, zeros, size, mean, corrcoef
 from numpy import dtype as dtypeFunc
 import itertools
 from nose.tools import assert_equals, assert_raises, assert_true
@@ -703,10 +703,9 @@ class TestImagesLocalCorr(PySparkTestCase):
             (2, array([[3.0, 4.0, 1.0], [5.0, 8.0, 1.0], [6.0, 2.0, 1.0]]))
         ]
 
-        from scipy.ndimage.filters import uniform_filter
         imgs = map(lambda x: x[1], dataLocal)
         # Blur each image and extract the center pixel
-        mn = map(lambda img: uniform_filter(img, 3)[1, 1], imgs)
+        mn = map(lambda img: mean(img), imgs)
         truth = corrcoef(mn, array([4.0, 2.0, 8.0]))[0, 1]
 
         corr = self.get_local_corr(dataLocal, 1, images=True)
@@ -721,10 +720,9 @@ class TestImagesLocalCorr(PySparkTestCase):
             (2, array([[3.0, 4.0, 1.0], [5.0, 8.0, 1.0], [6.0, 2.0, 1.0]]))
         ]
 
-        from scipy.ndimage.filters import uniform_filter
         imgs = map(lambda x: x[1], dataLocal)
         # Blur each image and extract the center pixel
-        mn = map(lambda img: uniform_filter(img, 3)[1, 1], imgs)
+        mn = map(lambda img: mean(img), imgs)
         truth = corrcoef(mn, array([4.0, 2.0, 8.0]))[0, 1]
 
         corr = self.get_local_corr(dataLocal, 1, images=True)

--- a/python/test/test_images.py
+++ b/python/test/test_images.py
@@ -686,7 +686,7 @@ class TestImagesLocalCorr(PySparkTestCase):
         from scipy.ndimage.filters import uniform_filter
         imgs = map(lambda x: x[1], dataLocal)
         # Blur each image and extract the center pixel
-        mn = map(lambda img: uniform_filter(img, 3)[1,1], imgs)
+        mn = map(lambda img: uniform_filter(img, 3)[1, 1], imgs)
         truth = corrcoef(mn, array([4.0, 2.0, 8.0]))[0, 1]
 
         corr = self.get_local_corr(dataLocal, 1, images=True)
@@ -704,7 +704,7 @@ class TestImagesLocalCorr(PySparkTestCase):
         from scipy.ndimage.filters import uniform_filter
         imgs = map(lambda x: x[1], dataLocal)
         # Blur each image and extract the center pixel
-        mn = map(lambda img: uniform_filter(img, 3)[1,1], imgs)
+        mn = map(lambda img: uniform_filter(img, 3)[1, 1], imgs)
         truth = corrcoef(mn, array([4.0, 2.0, 8.0]))[0, 1]
 
         corr = self.get_local_corr(dataLocal, 1, images=True)

--- a/python/thunder/rdds/images.py
+++ b/python/thunder/rdds/images.py
@@ -455,7 +455,7 @@ class Images(Data):
         """
         from numpy import corrcoef
 
-        nrecords = self.nrecords
+        nimages = self.nrecords
 
         # Spatially average the original image set over the specified neighborhood
         blurred = self.uniformFilter((neighborhood * 2) + 1)
@@ -463,11 +463,12 @@ class Images(Data):
         # Union the averaged images with the originals to create an Images object containing 2N images (where
         # N is the original number of images), ordered such that the first N images are the averaged ones.
         combined = self.rdd.union(blurred.rdd)
-        combinedImages = self._constructor(combined).__finalize__(self).renumber()
+        combinedImages = self._constructor(combined, nrecords=(2 * nimages)).__finalize__(self).renumber()
+        #combinedImages = Images(combined).renumber()
 
         # Correlate the first N (averaged) records with the last N (original) records
         series = combinedImages.toSeries()
-        corr = series.applyValues(lambda x: corrcoef(x[:nrecords], x[nrecords:])(0, 1))
+        corr = series.applyValues(lambda x: corrcoef(x[:nimages], x[nimages:])[0, 1])
 
         return corr
 

--- a/python/thunder/rdds/images.py
+++ b/python/thunder/rdds/images.py
@@ -16,7 +16,6 @@ class Images(Data):
 
     def __init__(self, rdd, dims=None, nrecords=None, dtype=None):
         super(Images, self).__init__(rdd, nrecords=nrecords, dtype=dtype)
-        print rdd.first()
         if dims and not isinstance(dims, Dimensions):
             try:
                 dims = Dimensions.fromTuple(dims)


### PR DESCRIPTION
The current version of localCorr, implemented in the SpatialSeries class, requires a significant amount of data duplication and shuffling, most of which can be optimized away. This version, suggested by @sofroniewn and @d-v-b, first does spatial averaging on an Images dataset, then appends the averaged data to the original before computing the correlation in time (by first converting to a Series and then correlating the first half of the series with the second). 

The localCorr unit tests have been ported from test_spatialseries.py to test_images.py, and all the relevant ones pass. 