### PR TITLE
BlockMethod to run any SIMA segmentation strategy

### DIFF
--- a/python/test/test_block_methods.py
+++ b/python/test/test_block_methods.py
@@ -1,8 +1,17 @@
+import unittest
+
 from thunder import ThunderContext
 from thunder import SourceExtraction
 
 from test_utils import PySparkTestCase
 
+_have_sima = False
+try:
+    import sima
+except ImportError:
+    pass
+else:
+    _have_sima = True
 
 class TestBlockMethod(PySparkTestCase):
 
@@ -19,4 +28,30 @@ class TestBlockMethod(PySparkTestCase):
         ep = 0.50
         cond1 = (model[0].distance([20, 20]) < ep) and (model[1].distance([40, 40]) < ep)
         cond2 = (model[0].distance([40, 40]) < ep) and (model[1].distance([20, 20]) < ep)
+        assert(cond1 or cond2)
+
+    @unittest.skipIf(not _have_sima, "SIMA not installed or not functional")
+    def test_sima(self):
+        """
+        (BlockMethod) with SIMA strategy
+        """
+        import sima.segment
+
+        # construct the SIMA strategy
+        simaStrategy = sima.segment.STICA(components=2)
+        simaStrategy.append(sima.segment.SparseROIsFromMasks(min_size=20))
+        simaStrategy.append(sima.segment.SmoothROIBoundaries())
+        simaStrategy.append(sima.segment.MergeOverlapping(threshold=0.5))
+
+        tsc = ThunderContext(self.sc)
+        data = tsc.makeExample('sources', dims=(60, 60), centers=[[20, 15], [40, 45]], noise=0.1, seed=42)
+
+        # create and fit the thunder extraction strategy
+        strategy = SourceExtraction('sima', simaStrategy=simaStrategy)
+        model = strategy.fit(data, size=(30, 30))
+
+        # order is irrelevant, but one of these must be true
+        ep = 1.5
+        cond1 = (model[0].distance([20, 15]) < ep) and (model[1].distance([40, 45]) < ep)
+        cond2 = (model[1].distance([20, 15]) < ep) and (model[0].distance([40, 45]) < ep)
         assert(cond1 or cond2)

--- a/python/thunder/extraction/block/methods/sima.py
+++ b/python/thunder/extraction/block/methods/sima.py
@@ -1,0 +1,50 @@
+from thunder.extraction.block.base import BlockMethod, BlockAlgorithm
+from thunder.extraction.source import Source
+
+
+class BlockSIMA(BlockMethod):
+
+    def __init__(self, simaStrategy, **kwargs):
+        algorithm = SIMABlockAlgorithm(simaStrategy, **kwargs)
+        super(self.__class__, self).__init__(algorithm, **kwargs)
+
+
+class SIMABlockAlgorithm(BlockAlgorithm):
+    """
+    Find sources using a SIMA SegmentationStrategy.
+
+    Parameters
+    ----------
+    sima_strategy : sima.segment.SegmentationStrategy
+        The particular strategy from SIMA to be used.
+    """
+    def __init__(self, simaStrategy, **extra):
+        self.strategy = simaStrategy
+
+    def extract(self, block):
+        import sima
+        import numpy
+
+        # reshape the block to (t, z, y, x, c)
+        dims = block.shape
+        if len(dims) == 3:  # (t, x, y)
+            reshapedBlock = block.reshape(dims[0], 1, dims[2], dims[1], 1)
+        else:  # (t, x, y, z)
+            reshapedBlock = block.reshape(dims[0], dims[3], dims[2], dims[1], 1)
+
+        # create SIMA dataset from block
+        dataset = sima.ImagingDataset([sima.Sequence.create('ndarray', reshapedBlock)], None)
+
+        # apply the sima strategy to the dataset
+        rois = self.strategy.segment(dataset)
+
+        # convert the coordinates between the SIMA and thunder conventions
+        coords = [numpy.asarray(numpy.where(numpy.array(roi))).T for roi in rois]
+        if len(dims) == 3:
+            coords = [c[:, 1:] for c in coords]
+        coords = [c[:, ::-1] for c in coords]
+
+        # format the sources
+        sources = [Source(c) for c in coords]
+
+        return sources

--- a/python/thunder/extraction/block/methods/sima.py
+++ b/python/thunder/extraction/block/methods/sima.py
@@ -1,3 +1,5 @@
+from numpy import array, asarray, where
+
 from thunder.extraction.block.base import BlockMethod, BlockAlgorithm
 from thunder.extraction.source import Source
 
@@ -15,7 +17,7 @@ class SIMABlockAlgorithm(BlockAlgorithm):
 
     Parameters
     ----------
-    sima_strategy : sima.segment.SegmentationStrategy
+    simaStrategy : sima.segment.SegmentationStrategy
         The particular strategy from SIMA to be used.
     """
     def __init__(self, simaStrategy, **extra):
@@ -23,7 +25,6 @@ class SIMABlockAlgorithm(BlockAlgorithm):
 
     def extract(self, block):
         import sima
-        import numpy
 
         # reshape the block to (t, z, y, x, c)
         dims = block.shape
@@ -39,7 +40,7 @@ class SIMABlockAlgorithm(BlockAlgorithm):
         rois = self.strategy.segment(dataset)
 
         # convert the coordinates between the SIMA and thunder conventions
-        coords = [numpy.asarray(numpy.where(numpy.array(roi))).T for roi in rois]
+        coords = [asarray(where(array(roi))).T for roi in rois]
         if len(dims) == 3:
             coords = [c[:, 1:] for c in coords]
         coords = [c[:, ::-1] for c in coords]

--- a/python/thunder/extraction/extraction.py
+++ b/python/thunder/extraction/extraction.py
@@ -9,11 +9,13 @@ class SourceExtraction(object):
     def __new__(cls, method, **kwargs):
 
         from thunder.extraction.block.methods.nmf import BlockNMF
+        from thunder.extraction.block.methods.sima import BlockSIMA
         from thunder.extraction.feature.methods.localmax import LocalMax
 
         EXTRACTION_METHODS = {
             'nmf': BlockNMF,
-            'localmax': LocalMax
+            'localmax': LocalMax,
+            'sima': BlockSIMA
         }
 
         checkParams(method, EXTRACTION_METHODS.keys())


### PR DESCRIPTION
I've created a simple BlockMethod/BlockAlgorithm pair that should allow any sima segmentation strategy to be run on a thunder block. Included is a single test case, which only runs if sima is installed. The test case passes on my laptop.

On a related note, I may try to simplify the dependencies of SIMA a bit so that it might be made a dependency of thunder without much pain. The current dependencies are:

    Python 2.7
    numpy >= 1.6.2
    scipy >= 0.13.0
    scikit-image >= 0.9.3
    scikit-learn >= 0.11
    shapely >= 1.2.14
    pillow >= 2.6.1
    future

@freeman-lab Let me know which ones you think would have to best converted to optional dependencies prior to making sima a thunder dependency.