### PR TITLE
Add in spark-ec2-git-repo and spark-ec2-git-branch default parameters

### DIFF
--- a/python/thunder/utils/ec2.py
+++ b/python/thunder/utils/ec2.py
@@ -452,7 +452,11 @@ if __name__ == "__main__":
         parser.add_option("--placement-group", type="string", default=None,
                           help="Which placement group to try and launch instances into. Assumes placement "
                                "group is already created.")
-
+    parser.add_option("--spark-ec2-git-repo", default="https://github.com/mesos/spark-ec2",
+                      help="Github repo from which to checkout spark-ec2 (default: %default)")
+    parser.add_option("--spark-ec2-git-branch", default="branch-1.3",
+                      help="Github repo branch of spark-ec2 to use (default: %default)")
+        
     (opts, args) = parser.parse_args()
     if len(args) != 2:
         parser.print_help()

--- a/python/thunder/utils/ec2.py
+++ b/python/thunder/utils/ec2.py
@@ -456,7 +456,11 @@ if __name__ == "__main__":
                       help="Github repo from which to checkout spark-ec2 (default: %default)")
     parser.add_option("--spark-ec2-git-branch", default="branch-1.3",
                       help="Github repo branch of spark-ec2 to use (default: %default)")
-        
+    parser.add_option("--private-ips", action="store_true", default=False,
+                      help="Use private IPs for instances rather than public if VPC/subnet " +
+                      "requires that.")
+
+    
     (opts, args) = parser.parse_args()
     if len(args) != 2:
         parser.print_help()


### PR DESCRIPTION
New in 1.4.0, they changed the way they did AMI discovery.  See:  https://github.com/apache/spark/commit/b884daa58084d4f42e2318894067565b94e07f9d

Essentially, it relies on a default parameter that we didn’t have.  I followed the examples from the other parameters and added the default in line. 

I am spinning up clusters now, it got further than it did before, but they’re not up yet.  If they don’t spin up, I’ll post a comment.  @freeman-lab 