### PR TITLE
Change default image partitioning

### DIFF
--- a/python/thunder/utils/context.py
+++ b/python/thunder/utils/context.py
@@ -188,7 +188,8 @@ class ThunderContext():
             to True to ensure consistent keys.
 
         npartitions: positive int, optional, default = None
-            Specify number of partitions for the RDD, if unspecified will use 1 partition per image.
+            Specify number of partitions for the RDD, if unspecified will use as many partitions
+            as available cores
 
         renumber: boolean, optional, default = False
             Recalculate keys for records after images are loading. Only necessary if different files contain
@@ -207,6 +208,9 @@ class ThunderContext():
 
         from thunder.rdds.fileio.imagesloader import ImagesLoader
         loader = ImagesLoader(self._sc)
+
+        if npartitions is None:
+            npartitions = self._sc.defaultParallelism
 
         # Checking StartIdx is smaller or equal to StopIdx
         if startIdx is not None and stopIdx is not None and startIdx > stopIdx:


### PR DESCRIPTION
This PR sets the default based on the number of cores, rather than the number of images. In practice, this significantly speeds up reductions (by avoiding excess partitioning), and has no apparent cost to subsequent performance, though this should be evaluated with additional testing.