### PR TITLE
remove dead packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ setup(
               'thunder.extraction.block.methods',
               'thunder.extraction.feature.methods',
               'thunder.registration',
-              'thunder.registration.regmethods',
-              'thunder.lib',
               'thunder.rdds',
               'thunder.rdds.fileio',
               'thunder.rdds.imgblocks',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
               'thunder.extraction.block.methods',
               'thunder.extraction.feature.methods',
               'thunder.registration',
+              'thunder.registration.methods',
               'thunder.rdds',
               'thunder.rdds.fileio',
               'thunder.rdds.imgblocks',


### PR DESCRIPTION
@freeman-lab `python setup.py install` fails on master due to these two lines which don’t exist in the source tree anymore.  Seems to work if I drop them- is there anything else that needs to change in this file?  I’ll tack it on if so.