### PR TITLE
Switch travis to Spark 1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,13 @@ install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   # Install Spark
-  - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.3.0-bin-hadoop1.tgz
-  - tar -xzf spark-1.3.0-bin-hadoop1.tgz
+  - wget http://www.apache.org/dyn/closer.cgi/spark/spark-1.4.1/spark-1.4.1-bin-hadoop1.tgz
+  - tar -xzf spark-1.4.1-bin-hadoop1.tgz
   # Workaround for Travis issue with POSIX semaphores; see
   # https://github.com/travis-ci/travis-cookbooks/issues/155
   - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
 
 script:
-    - export SPARK_HOME=`pwd`/spark-1.3.0-bin-hadoop1
+    - export SPARK_HOME=`pwd`/spark-1.4.1-bin-hadoop1
     - cd test
     - ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   # Install Spark
-  - wget http://www.apache.org/dyn/closer.cgi/spark/spark-1.4.1/spark-1.4.1-bin-hadoop1.tgz
+  - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.4.1-bin-hadoop1.tgz
   - tar -xzf spark-1.4.1-bin-hadoop1.tgz
   # Workaround for Travis issue with POSIX semaphores; see
   # https://github.com/travis-ci/travis-cookbooks/issues/155


### PR DESCRIPTION
Tests should all be running on the latest Spark release (1.4.1), this PR ensures we're testing against the latest on Travis.