### PR TITLE
adding python versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: python
 
 python:
+  - "2.6"
   - "2.7"
-
+  - "3.3"
+  - "3.4"
+  
 jdk:
   - openjdk7
 
 before_install:
   # install miniconda
   - sudo apt-get update
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget http://repo.continuum.io/miniconda/Miniconda3-3.7.3-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r


### PR DESCRIPTION
Initial work to explicitly test other Python versions (2.6, 3.3, and 3.4) via Travis.  Opening a PR to see if the build passes.

@freeman-lab I took out the if/else here that downloaded a different miniconda.  Is it needed?  For instance [here](https://github.com/python-visualization/folium/blob/master/.travis.yml), although the versions are passed through in a different way, they use the same miniconda script for all 3 python versions.

I am happy to change it back if it's installing something specific.