### PR TITLE
Fixed related to issue #152: "Notebook pylab error on ec2"

### DIFF
--- a/bin/setup-notebook-ec2-sshtunnel
+++ b/bin/setup-notebook-ec2-sshtunnel
@@ -9,7 +9,7 @@ c = get_config()
 c.NotebookApp.open_browser = False
 # It is a good idea to put it on a known, fixed port
 c.NotebookApp.port = 8888" >> /root/.ipython/profile_default/ipython_notebook_config.py
-echo 'export IPYTHON_OPTS="notebook --pylab inline"' >> /root/.bash_profile
+echo 'export IPYTHON_OPTS="notebook"' >> /root/.bash_profile
 
 echo -e "\n\n\n"
 echo "-----------------------------------------------------------------"


### PR DESCRIPTION
Issue #152 was fixed in setup-notebook-ec2, but not setup-notebok-ec2-sshtunnel.  This quick pull request fixes the same bug in setup-noteboke-ec2-sshtunnel.

-Aaron