### PR TITLE
fixed indexing issue in detrending

### DIFF
--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -64,7 +64,7 @@ class TestTimeSeriesMethods(TimeSeriesTestCase):
         rdd = self.sc.parallelize([(0, array([1, 2, 3, 4, 5]))])
         data = TimeSeries(rdd).detrend('linear')
         # detrending linearly increasing data should yield all 0s
-        assert(allclose(data.first()[1], array([0, 0, 0, 0, 0])))
+        assert(allclose(data.first()[1], array([1, 1, 1, 1, 1])))
 
     def test_normalization_bypercentile(self):
         rdd = self.sc.parallelize([(0, array([1, 2, 3, 4, 5], dtype='float16'))])

--- a/thunder/rdds/timeseries.py
+++ b/thunder/rdds/timeseries.py
@@ -270,7 +270,7 @@ class TimeSeries(Series):
                 order = 5
 
         def func(y):
-            x = arange(1, len(y)+1)
+            x = arange(len(y))
             p = polyfit(x, y, order)
             p[-1] = 0
             yy = polyval(p, x)


### PR DESCRIPTION
`TimeSeries.detrend(data)` can return values outside of the range of the values in `data`. This is because the `TimeSeries.detrend()` method uses the wrong indices when calling `numpy.polyfit(vector, indices)`: specifically, the indices are shifted up by one. This PR fixes this bug by shifting the indices down by one.