### PR TITLE
Update spark version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,13 @@ install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   # Install Spark
-  - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.4.1-bin-hadoop1.tgz
-  - tar -xzf spark-1.4.1-bin-hadoop1.tgz
+  - wget http://d3kbcqa49mib13.cloudfront.net/spark-1.5.0-bin-hadoop1.tgz
+  - tar -xzf spark-1.5.0-bin-hadoop1.tgz
   # Workaround for Travis issue with POSIX semaphores; see
   # https://github.com/travis-ci/travis-cookbooks/issues/155
   - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
 
 script:
-    - export SPARK_HOME=`pwd`/spark-1.4.1-bin-hadoop1
+    - export SPARK_HOME=`pwd`/spark-1.5.0-bin-hadoop1
     - cd test
     - ./run_tests.sh


### PR DESCRIPTION
Updates the version of Spark to 1.5.0. All tests with 1.5.0 run fine locally, but let's confirm on travis as well.