### PR TITLE
Python 2 and 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "2.7"
+  - "3.4"
 
 jdk:
   - openjdk7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ numpy
 scipy
 scikit-image
 boto
+pillow
+six
 bolt-python >= 0.3.0
 checkist >= 1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,5 @@ numpy
 scipy
 scikit-image
 boto
-pillow
-six
 bolt-python >= 0.3.0
 checkist >= 1.0.0

--- a/test/test_series_io.py
+++ b/test/test_series_io.py
@@ -81,8 +81,7 @@ def test_from_text_skip(tmpdir):
 def test_from_binary(tmpdir, eng):
     a = arange(8, dtype='int16').reshape((4, 2))
     p = os.path.join(str(tmpdir), 'data.bin')
-    with open(p, 'w') as f:
-        f.write(a)
+    a.tofile(p)
     data = frombinary(p, shape=[4, 2], dtype='int16', engine=eng)
     assert allclose(data.shape, (4, 2))
     assert allclose(data.index, [0, 1])
@@ -94,8 +93,7 @@ def test_from_binary_skip(tmpdir, eng):
     v = [[0, i] for i in range(10)]
     a = array([kv[0] + kv[1] for kv in zip(k, v)], dtype='int16')
     p = os.path.join(str(tmpdir), 'data.bin')
-    with open(p, 'w') as f:
-        f.write(a)
+    a.tofile(p)
     data = frombinary(p, shape=[10, 2], dtype='int16', skip=1, engine=eng)
     assert allclose(data.shape, (10, 2))
     assert allclose(data.index, [0, 1])

--- a/thunder/base.py
+++ b/thunder/base.py
@@ -451,7 +451,11 @@ class Data(Base):
             return self._constructor(op(self.values, other.values)).__finalize__(self)
 
         if self.mode == 'spark' and isinstance(other, Data):
-            func = lambda ((k1, x), (k2, y)): (k1, op(x, y))
+
+            def func(record):
+                (k1, x), (k2, y) = record
+                return k1, op(x, y)
+
             rdd = self.tordd().zip(other.tordd()).map(func)
             barray = BoltArraySpark(rdd, shape=self.shape, dtype=self.dtype)
             return self._constructor(barray).__finalize__(self)

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -1,5 +1,7 @@
 import logging
 from numpy import ndarray, arange, amax, amin, size, asarray, random, prod
+# Name changes between Python 2 and 3
+from six.moves import xrange
 
 from ..base import Data
 

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -165,7 +165,7 @@ class Images(Data):
         Execute a function on each image
         """
         if self.mode == 'spark':
-            self.values.tordd().map(lambda (k, v): (k[0], v)).foreach(func)
+            self.values.tordd().map(lambda kv: (kv[0][0], kv[1])).foreach(func)
         else:
             [func(kv) for kv in enumerate(self.values)]
 

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -1,7 +1,5 @@
 import logging
 from numpy import ndarray, arange, amax, amin, size, asarray, random, prod
-# Name changes between Python 2 and 3
-from six.moves import xrange
 
 from ..base import Data
 
@@ -320,8 +318,8 @@ class Images(Data):
         def roundup(a, b):
             return (a + b - 1) // b
 
-        slices = [slice(0, dims[i], factor[i]) for i in xrange(ndims)]
-        newdims = tuple([roundup(dims[i], factor[i]) for i in xrange(ndims)])
+        slices = [slice(0, dims[i], factor[i]) for i in range(ndims)]
+        newdims = tuple([roundup(dims[i], factor[i]) for i in range(ndims)])
 
         return self.map(lambda v: v[slices], dims=newdims)
 

--- a/thunder/images/readers.py
+++ b/thunder/images/readers.py
@@ -2,8 +2,6 @@ import itertools
 import checkist
 from io import BytesIO
 from numpy import frombuffer, prod, random, asarray, expand_dims
-# library reorganization between Python 2 and 3
-from six.moves import xrange
 
 from ..utils import check_spark
 spark = check_spark()
@@ -340,7 +338,7 @@ def fromtif(path, ext='tif', start=None, stop=None, recursive=False,
         ary = tfh.asarray()
         pageCount = ary.shape[0]
         if nplanes is not None:
-            values = [ary[i:(i+nplanes)] for i in xrange(0, ary.shape[0], nplanes)]
+            values = [ary[i:(i+nplanes)] for i in range(0, ary.shape[0], nplanes)]
         else:
             values = [ary]
         tfh.close()
@@ -352,7 +350,7 @@ def fromtif(path, ext='tif', start=None, stop=None, recursive=False,
         if nplanes and (pageCount % nplanes):
             raise ValueError("nplanes '%d' does not evenly divide '%d'" % (nplanes, pageCount))
         nvals = len(values)
-        keys = [(idx*nvals + timepoint,) for timepoint in xrange(nvals)]
+        keys = [(idx*nvals + timepoint,) for timepoint in range(nvals)]
         return zip(keys, values)
 
     recount = False if nplanes is None else True

--- a/thunder/images/readers.py
+++ b/thunder/images/readers.py
@@ -2,6 +2,8 @@ import itertools
 import checkist
 from io import BytesIO
 from numpy import frombuffer, prod, random, asarray, expand_dims
+# library reorganization between Python 2 and 3
+from six.moves import xrange
 
 from ..utils import check_spark
 spark = check_spark()
@@ -239,7 +241,7 @@ def frombinary(path, shape=None, dtype=None, ext='bin', start=None, stop=None, r
     from thunder.readers import get_file_reader, FileNotFoundError
     try:
         reader = get_file_reader(path)(credentials=credentials)
-        buf = reader.read(path, filename=conf)
+        buf = reader.read(path, filename=conf).decode('utf-8')
         params = json.loads(buf)
     except FileNotFoundError:
         params = {}
@@ -289,7 +291,7 @@ def frombinary(path, shape=None, dtype=None, ext='bin', start=None, stop=None, r
             yield (idx*npoints + timepoint,), ary[slices].squeeze()
 
     recount = False if nplanes is None else True
-    append = [nplanes] if nplanes > 1 else []
+    append = [nplanes] if (nplanes is not None and nplanes > 1) else []
     newdims = tuple(list(shape[:-1]) + append) if nplanes else shape
     return frompath(path, accessor=getarray, ext=ext, start=start,
                     stop=stop, recursive=recursive, npartitions=npartitions,

--- a/thunder/images/readers.py
+++ b/thunder/images/readers.py
@@ -180,7 +180,12 @@ def frompath(path, accessor=None, ext=None, start=None, stop=None, recursive=Fal
             data = data.flatMap(accessor)
         if recount:
             nrecords = None
-            data = data.values().zipWithIndex().map(lambda (ary, idx): ((idx,), ary))
+
+            def switch(record):
+                ary, idx = record
+                return (idx,), ary
+
+            data = data.values().zipWithIndex().map(switch)
         else:
             nrecords = reader.nfiles
         return fromrdd(data, nrecords=nrecords, dims=dims, dtype=dtype)
@@ -428,9 +433,9 @@ def fromexample(name=None, engine=None):
     datasets = ['mouse', 'fish']
 
     if name is None:
-        print 'Availiable example image datasets'
+        print('Availiable example image datasets')
         for d in datasets:
-            print '- ' + d
+            print('- ' + d)
         return
 
     checkist.opts(name, datasets)

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -3,14 +3,18 @@ import fnmatch
 import glob
 import itertools
 import os
-import urllib
-import urlparse
 import logging
+# standard library reorganization between Python 2 and 3
+try:
+    from urllib.parse import urlparse
+    from urllib.request import url2pathname
+except ImportError:
+    from urlparse import urlparse
+    from urllib import url2pathname
 
 from .utils import check_spark
 spark = check_spark()
 logging.getLogger('boto').setLevel(logging.CRITICAL)
-
 
 def addextension(path, ext=None):
     """
@@ -56,7 +60,7 @@ def readlocal(path, offset=None, size=-1):
             if offset:
                 f.seek(offset)
             buf = f.read(size)
-    except IOError, e:
+    except IOError as e:
         if e.errno == errno.ENOENT:
             raise FileNotFoundError(e)
         else:
@@ -93,7 +97,7 @@ def listflat(path, ext=None):
     return sorted(files)
 
 def uri_to_path(uri):
-    path = urllib.url2pathname(urlparse.urlparse(uri).path)
+    path = url2pathname(urlparse(uri).path)
     if uri and (not path):
         raise ValueError("Could not interpret %s as URI. " +
                          "Paths in URIs should start with 'file:///', not 'file://'")
@@ -143,8 +147,7 @@ class LocalParallelReader(object):
         if spark and isinstance(self.engine, spark):
             npartitions = min(npartitions, nfiles) if npartitions else nfiles
             rdd = self.engine.parallelize(enumerate(files), npartitions)
-            return rdd.map(lambda (k, v): (k, readlocal(v)))
-
+            return rdd.map(lambda kv: (kv[0], readlocal(kv[1])))
         else:
             return [(k, readlocal(v)) for k, v in enumerate(files)]
 
@@ -225,7 +228,7 @@ class BotoClient(object):
         prefix = ''
         postfix = ''
 
-        parsed = urlparse.urlparse(query)
+        parsed = urlparse(query)
         query = parsed.path.lstrip(delim)
         bucket = parsed.netloc
 
@@ -603,10 +606,9 @@ def normalize_scheme(path, ext):
     """
     Normalize scheme for paths related to hdfs
     """
-    import urlparse
     path = addextension(path, ext)
 
-    parsed = urlparse.urlparse(path)
+    parsed = urlparse(path)
     if parsed.scheme:
         # this appears to already be a fully-qualified URI
         return path
@@ -624,7 +626,7 @@ def get_by_scheme(path, lookup, default):
     """
     Helper function used by get*ForPath().
     """
-    parsed = urlparse.urlparse(path)
+    parsed = urlparse(path)
     class_name = lookup.get(parsed.scheme, default)
     if class_name is None:
         raise NotImplementedError("No implementation for scheme " + parsed.scheme)

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -1,16 +1,18 @@
 import errno
 import fnmatch
 import glob
-import itertools
 import os
 import logging
-# standard library reorganization between Python 2 and 3
+
+# library reorganization between Python 2 and 3
 try:
     from urllib.parse import urlparse
     from urllib.request import url2pathname
 except ImportError:
     from urlparse import urlparse
     from urllib import url2pathname
+from six.moves import filter
+from six import next
 
 from .utils import check_spark
 spark = check_spark()
@@ -298,10 +300,10 @@ class BotoClient(object):
         results = bucket.list(prefix=key, delimiter=listdelim)
         if postfix:
             func = lambda k_: BotoClient.filter_predicate(k_, postfix, inclusive=True)
-            return itertools.ifilter(func, results)
+            return filter(func, results)
         elif not directories:
             func = lambda k_: BotoClient.filter_predicate(k_, delim, inclusive=False)
-            return itertools.ifilter(func, results)
+            return filter(func, results)
         else:
             return results
 
@@ -462,14 +464,14 @@ class BotoFileReader(BotoClient):
         """
         scheme, keys = self.getkeys(path, filename=filename)
         try:
-            key = keys.next()
+            key = next(keys)
         except StopIteration:
             raise FileNotFoundError("Could not find object for: '%s'" % path)
 
         # we expect to only have a single key returned
         nextKey = None
         try:
-            nextKey = keys.next()
+            nextKey = next(keys)
         except StopIteration:
             pass
         if nextKey:

--- a/thunder/series/series.py
+++ b/thunder/series/series.py
@@ -5,6 +5,9 @@ from numpy import array, sum, mean, median, std, size, arange, percentile,\
     ravel, logical_not, max, min, unravel_index, prod, random, shape, \
     dot, outer, expand_dims, ScalarType, ndarray
 from bolt.utils import tupleize
+# naming changes between Python 2 and 3
+from six import string_types
+from six.moves import xrange
 
 from ..base import Data
 
@@ -240,7 +243,7 @@ class Series(Data):
         # handle lists, strings, and ints
         if not isinstance(crit, types.FunctionType):
             # set("foo") -> {"f", "o"}; wrap in list to prevent:
-            if isinstance(crit, basestring):
+            if isinstance(crit, string_types):
                 critlist = set([crit])
             else:
                 try:
@@ -266,7 +269,7 @@ class Series(Data):
             return self
 
         # use fast logical indexing to get the new values
-        subinds = where(map(lambda x: crit(x), index))
+        subinds = where([crit(i) for i in index])
         new = self.map(lambda x: x[subinds], index=newindex)
 
         # if singleton, need to check whether it's an array or a scalar/int

--- a/thunder/series/series.py
+++ b/thunder/series/series.py
@@ -7,7 +7,6 @@ from numpy import array, sum, mean, median, std, size, arange, percentile,\
 from bolt.utils import tupleize
 # naming changes between Python 2 and 3
 from six import string_types
-from six.moves import xrange
 
 from ..base import Data
 
@@ -47,7 +46,7 @@ class Series(Data):
         if self._index is None:
             self._index = arange(self.shape[-1])
         return self._index
-        
+
     @index.setter
     def index(self, value):
         lenself = len(self.index)
@@ -168,7 +167,7 @@ class Series(Data):
         Filter by applying a function to each series.
         """
         return self._filter(func, axis=self.baseaxes)
-    
+
     def reduce(self, func):
         """
         Reduce over series.
@@ -214,7 +213,7 @@ class Series(Data):
     def between(self, left, right):
         """
         Select subset of values within the given index range
-        
+
         Inclusive on the left; exclusive on the right.
 
         Parameters
@@ -416,7 +415,7 @@ class Series(Data):
     def series_percentile(self, q):
         """
         Compute the value percentile of each record in a Series.
-        
+
         Parameters
         ----------
         q : scalar
@@ -496,13 +495,13 @@ class Series(Data):
     def _makemasks(self, index=None, level=0):
         """
         Internal function for generating masks for selecting values based on multi-index values.
-    
+
         As all other multi-index functions will call this function, basic type-checking is also
         performed at this stage.
         """
         if index is None:
             index = self.index
-        
+
         try:
             dims = len(array(index).shape)
             if dims == 1:
@@ -518,12 +517,12 @@ class Series(Data):
         lenIdx = index.shape[0]
         nlevels = index.shape[1]
 
-        combs = product(*[unique(index.T[i, :]) for i in xrange(nlevels)])
+        combs = product(*[unique(index.T[i, :]) for i in range(nlevels)])
         combs = array([l for l in combs])
 
-        masks = array([[array_equal(index[i], c) for i in xrange(lenIdx)] for c in combs])
+        masks = array([[array_equal(index[i], c) for i in range(lenIdx)] for c in combs])
 
-        return zip(*[(masks[x], combs[x]) for x in xrange(len(masks)) if masks[x].any()])
+        return zip(*[(masks[x], combs[x]) for x in range(len(masks)) if masks[x].any()])
 
     def _map_by_index(self, function, level=0):
         """
@@ -543,7 +542,7 @@ class Series(Data):
         newindex = array(ind)
         if len(newindex[0]) == 1:
             newindex = ravel(newindex)
-        return self.map(lambda v: asarray([array(function(v[masks[x]])) for x in xrange(nMasks)]),
+        return self.map(lambda v: asarray([array(function(v[masks[x]])) for x in range(nMasks)]),
                         index=newindex)
 
     def select_by_index(self, val, level=0, squeeze=False, filter=False, return_mask=False):
@@ -570,7 +569,7 @@ class Series(Data):
             Specifies which levels in the multi-index to use when performing selection. If a single
             level is selected, the list can be replaced with an integer. Must be the same length
             as val.
-        
+
         squeeze : bool, optional, default=False
             If True, the multi-index of the resulting Series will drop any levels that contain
             only a single value because of the selection. Useful if indices are used as unique
@@ -591,7 +590,7 @@ class Series(Data):
             val[0]
         except:
             val = [val]
-        
+
         remove = []
         if len(level) == 1:
             try:
@@ -601,14 +600,14 @@ class Series(Data):
             if squeeze and not filter and len(val) == 1:
                 remove.append(level[0])
         else:
-            for i in xrange(len(val)):
+            for i in range(len(val)):
                 try:
                     val[i][0]
                 except:
                     val[i] = [val[i]]
                 if squeeze and not filter and len(val[i]) == 1:
                     remove.append(level[i])
-                                
+
         if len(level) != len(val):
             raise ValueError("List of levels must be same length as list of corresponding values")
 
@@ -617,7 +616,7 @@ class Series(Data):
 
         masks, ind = self._makemasks(index=self.index, level=level)
         nmasks = len(masks)
-        masks = array([masks[x] for x in xrange(nmasks) if tuple(ind[x]) in selected])
+        masks = array([masks[x] for x in range(nmasks) if tuple(ind[x]) in selected])
 
         final_mask = masks.any(axis=0)
         if filter:
@@ -647,19 +646,19 @@ class Series(Data):
     def aggregate_by_index(self, function, level=0):
         """
         Aggregrate data in each record, grouping by index values.
-        
+
         For each unique value of the index, applies a function to the group
         indexed by that value. Returns a Series indexed by those unique values.
         For the result to be a valid Series object, the aggregating function should
         return a simple numeric type. Also allows selection of levels within a
         multi-index. See select_by_index for more info on indices and multi-indices.
-        
+
         Parameters:
         -----------
         function : function
             Aggregating function to map to Series values. Should take a list or ndarray
             as input and return a simple numeric value.
-            
+
         level : list of ints, optional, default=0
             Specifies the levels of the multi-index to use when determining unique index values.
             If only a single level is desired, can be an int.
@@ -675,7 +674,7 @@ class Series(Data):
         -----------
         stat : string
             Statistic to be computed: sum, mean, median, stdev, max, min, count
-            
+
         level : list of ints, optional, default=0
             Specifies the levels of the multi-index to use when determining unique index values.
             If only a single level is desired, can be an int.
@@ -697,7 +696,7 @@ class Series(Data):
         Compute sums for each unique index value (across levels, if multi-index)
         """
         return self.stat_by_index(level=level, stat='sum')
-    
+
     def mean_by_index(self, level=0):
         """
         Compute means for each unique index value (across levels, if multi-index)

--- a/thunder/series/series.py
+++ b/thunder/series/series.py
@@ -770,7 +770,7 @@ class Series(Data):
                 global mat
                 mat += outer(x, x)
 
-            rdd.map(lambda (k, v): v).foreach(outer_sum)
+            rdd.values().foreach(outer_sum)
             return self._constructor(mat.value, index=self.index)
 
         if self.mode == 'local':

--- a/thunder/series/timeseries.py
+++ b/thunder/series/timeseries.py
@@ -29,8 +29,9 @@ class TimeSeries(Series):
         window : int
             Window size
         """
-        before = window / 2
-        after = window / 2 + divmod(window, 2)[1]
+        div = divmod(window, 2)
+        before = div[0]
+        after = div[0] + div[1]
         index = asarray(self.index)
         indices = asarray(indices)
         if where(index == max(indices))[0][0] + after > len(index):
@@ -39,7 +40,7 @@ class TimeSeries(Series):
         if where(index == min(indices))[0][0] - before < 0:
             raise ValueError("Minimum requested index %g, with window %g, is less than 0"
                              % (min(indices), window))
-        masks = [arange(where(index == i)[0][0]-before, where(index == i)[0][0]+after) for i in indices]
+        masks = [arange(where(index == i)[0][0]-before, where(index == i)[0][0]+after, dtype='int') for i in indices]
         return masks
 
     def mean_by_window(self, indices, window):

--- a/thunder/series/writers.py
+++ b/thunder/series/writers.py
@@ -20,7 +20,7 @@ def tobinary(series, path, prefix='series', overwrite=False, credentials=None):
         If true, path and all its contents will be deleted and
         recreated as partof this call.
     """
-    import cStringIO as StringIO
+    from six import BytesIO
     from thunder.utils import check_path
     from thunder.writers import get_parallel_writer
 
@@ -30,7 +30,7 @@ def tobinary(series, path, prefix='series', overwrite=False, credentials=None):
 
     def tobuffer(kv):
         firstkey = None
-        buf = StringIO.StringIO()
+        buf = BytesIO()
         for k, v in kv:
             if firstkey is None:
                 firstkey = k

--- a/thunder/writers.py
+++ b/thunder/writers.py
@@ -1,14 +1,19 @@
 import os
 import shutil
-import urllib
-import urlparse
+# standard library reorganization between Python 2 and 3
+try:
+    from urllib.parse import urlparse
+    from urllib.request import url2pathname
+except ImportError:
+    from urlparse import urlparse
+    from urllib import url2pathname
 
 from thunder.readers import BotoClient, get_by_scheme
 
 
 class LocalParallelWriter(object):
     def __init__(self, path, overwrite=False, **kwargs):
-        self._path = urllib.url2pathname(urlparse.urlparse(path).path)
+        self._path = url2pathname(urlparse(path).path)
         self._overwrite = overwrite
         self._checked = False
         self.check_directory()
@@ -100,7 +105,7 @@ class BotoParallelWriter(BotoWriter):
 
 class LocalFileWriter(object):
     def __init__(self, path, filename, overwrite=False, **kwargs):
-        self._path = os.path.join(urllib.url2pathname(urlparse.urlparse(path).path), filename)
+        self._path = os.path.join(url2pathname(urlparse(path).path), filename)
         self._filename = filename
         self._overwrite = overwrite
         self._checked = False
@@ -118,7 +123,7 @@ class LocalFileWriter(object):
     def write(self, buf):
         self.check_file()
         with open(os.path.join(self._path), 'wb') as f:
-            f.write(buf)
+            f.write(buf.encode('utf-8'))
 
 
 class BotoFileWriter(BotoWriter):


### PR DESCRIPTION
This PR address one of the goals of #243 -- making v1.0.0 compatible both Python 2 and 3

- [x] get unit tests to run
   - [x] base
   - [x] blocks
   - [x] images
   - [x] images_io
   - [x] readers
   - [x] series
   - [x] series_io
   - [x] timerseries
- [x] update Travis to test both Python 2 and 3