### PR TITLE
Blocks Update

### DIFF
--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -63,5 +63,5 @@ def test_shape(engspark):
     data = fromlist([ones((30, 30)) for _ in range(0, 3)], engine=engspark)
     blocks = data.toblocks((10, 10))
     values = [v for k, v in blocks.tordd().collect()]
-    assert blocks.subshape == (3, 10, 10)
+    assert blocks.blockshape == (3, 10, 10)
     assert all([v.shape == (3, 10, 10) for v in values])

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -3,77 +3,74 @@ from numpy import arange, array, allclose, ones
 
 from thunder.images.readers import fromlist
 
-pytestmark = pytest.mark.usefixtures("eng")
+pytestmark = pytest.mark.usefixtures("eng", "engspark")
 
 
-def test_conversion(eng):
+def test_conversion(engspark):
     a = arange(8).reshape((4, 2))
-    data = fromlist([a, a], engine=eng)
-    if data.mode == 'local':
-        pass
-    if data.mode == 'spark':
-        vals = data.toblocks((2, 2)).tordd().sortByKey().values().collect()
-        truth = [array([a[0:2, 0:2], a[0:2, 0:2]]), array([a[2:4, 0:2], a[2:4, 0:2]])]
-        assert allclose(vals, truth)
+    data = fromlist([a, a], engine=engspark)
+    vals = data.toblocks((2, 2)).tordd().sortByKey().values().collect()
+    truth = [array([a[0:2, 0:2], a[0:2, 0:2]]), array([a[2:4, 0:2], a[2:4, 0:2]])]
+    assert allclose(vals, truth)
 
 
-def test_full(eng):
+def test_full(engspark):
     a = arange(8).reshape((4, 2))
-    data = fromlist([a, a], engine=eng)
-    if data.mode == 'local':
-        assert allclose(data.toblocks().values, data.values)
-    if data.mode == 'spark':
-        vals = data.toblocks((4, 2)).tordd().values().collect()
-        truth = [a, a]
-        assert allclose(vals, truth)
+    data = fromlist([a, a], engine=engspark)
+    vals = data.toblocks((4, 2)).tordd().values().collect()
+    truth = [a, a]
+    assert allclose(vals, truth)
 
 
-def test_count(eng):
+def test_count(engspark):
     a = arange(8).reshape((2, 4))
-    data = fromlist([a], engine=eng)
-    if data.mode == 'local':
-        assert data.toblocks().count() == 1
-    if data.mode == 'spark':
-        assert data.toblocks((1, 1)).count() == 8
-        assert data.toblocks((1, 2)).count() == 4
-        assert data.toblocks((2, 2)).count() == 2
-        assert data.toblocks((2, 4)).count() == 1
+    data = fromlist([a], engine=engspark)
+    assert data.toblocks((1, 1)).count() == 8
+    assert data.toblocks((1, 2)).count() == 4
+    assert data.toblocks((2, 2)).count() == 2
+    assert data.toblocks((2, 4)).count() == 1
 
 
-def test_conversion_series(eng):
+def test_conversion_series(engspark):
     a = arange(8).reshape((4, 2))
-    data = fromlist([a], engine=eng)
+    data = fromlist([a], engine=engspark)
     vals = data.toblocks((1, 2)).toseries().toarray()
     assert allclose(vals, a)
 
 
-def test_conversion_series_3d(eng):
+def test_conversion_series_3d(engspark):
     a = arange(24).reshape((2, 3, 4))
-    data = fromlist([a], engine=eng)
+    data = fromlist([a], engine=engspark)
     vals = data.toblocks((2, 3, 4)).toseries().toarray()
     assert allclose(vals, a)
 
 
-def test_roundtrip(eng):
+def test_roundtrip(engspark):
     a = arange(8).reshape((4, 2))
-    data = fromlist([a, a], engine=eng)
+    data = fromlist([a, a], engine=engspark)
     vals = data.toblocks((2, 2)).toimages()
     assert allclose(vals.toarray(), data.toarray())
 
 
-def test_series_roundtrip_simple(eng):
+def test_series_roundtrip_simple(engspark):
     a = arange(8).reshape((4, 2))
-    data = fromlist([a, a], engine=eng)
+    data = fromlist([a, a], engine=engspark)
     vals = data.toseries().toimages()
     assert allclose(vals.toarray(), data.toarray())
 
 
-def test_shape(eng):
-    data = fromlist([ones((30, 30)) for _ in range(0, 3)], engine=eng)
+def test_shape(engspark):
+    data = fromlist([ones((30, 30)) for _ in range(0, 3)], engine=engspark)
     blocks = data.toblocks((10, 10))
+    values = [v for k, v in blocks.tordd().collect()]
+    assert blocks.blockshape == (3, 10, 10)
+    assert all([v.shape == (3, 10, 10) for v in values])
+
+def test_local_mode(eng):
+    a = arange(64).reshape((8, 8))
+    data = fromlist([a, a])
     if data.mode == 'local':
-        assert blocks.blockshape == (3, 30, 30)
-    if data.mode == 'spark':
-        values = [v for k, v in blocks.tordd().collect()]
-        assert blocks.blockshape == (3, 10, 10)
-        assert all([v.shape == (3, 10, 10) for v in values])
+        blocks = data.toblocks((4, 4))
+        assert allclose(blocks.values, data.values)
+        assert blocks.count() == 1
+        assert blocks.blockshape == (2, 8, 8)

--- a/thunder/blocks/blocks.py
+++ b/thunder/blocks/blocks.py
@@ -13,7 +13,11 @@ class Blocks(Base):
         super(Blocks, self).__init__(values)
 
     @property
-    def subshape(self):
+    def _constructor(self):
+        return Blocks
+
+    @property
+    def blockshape(self):
         return tuple(self.values.plan)
 
     def count(self):
@@ -23,6 +27,13 @@ class Blocks(Base):
         For lazy or distributed data, will force a computation.
         """
         return self.tordd().count()
+
+    def map(self, func, dims=None):
+        """
+        Apply an array -> array function to each block
+        """
+        mapped = self.values.map(func, value_shape=dims)
+        return self._constructor(mapped).__finalize__(self)
 
     def first(self):
         """

--- a/thunder/blocks/blocks.py
+++ b/thunder/blocks/blocks.py
@@ -1,4 +1,5 @@
 from ..base import Base
+import logging
 
 
 class Blocks(Base):
@@ -18,7 +19,11 @@ class Blocks(Base):
 
     @property
     def blockshape(self):
-        return tuple(self.values.plan)
+        if self.mode == 'spark':
+            return tuple(self.values.plan)
+
+        if self.mode == 'local':
+            return tuple(self.values.shape)
 
     def count(self):
         """
@@ -26,27 +31,49 @@ class Blocks(Base):
 
         For lazy or distributed data, will force a computation.
         """
-        return self.tordd().count()
+        if self.mode == 'spark':
+            return self.tordd().count()
+
+        if self.mode == 'local':
+            return 1
 
     def map(self, func, dims=None):
         """
         Apply an array -> array function to each block
         """
-        mapped = self.values.map(func, value_shape=dims)
-        return self._constructor(mapped).__finalize__(self)
+        if self.mode == 'spark':
+            mapped = self.values.map(func, value_shape=dims)
+
+        if self.mode == 'local':
+            if dims is not None:
+                logger = logging.getLogger('thunder')
+                logger.warn("dims has no meaning in Blocks.map in local mode")
+            mapped = func(self.values)
+
+        return self._constructor(mapped).__finalize__(self, noprop=('dtype',))
 
     def first(self):
         """
         Return the first element.
         """
-        return self.values.tordd().values().first()
+        if self.mode == 'spark':
+            return self.values.tordd().values().first()
+
+        if self.mode == 'local':
+            return self.values
 
     def toimages(self):
         """
         Convert blocks to images.
         """
         from thunder.images.images import Images
-        values = self.values.values_to_keys((0,)).unchunk()
+
+        if self.mode == 'spark':
+            values = self.values.values_to_keys((0,)).unchunk()
+
+        if self.mode == 'local':
+            values = self.values
+
         return Images(values)
 
     def toseries(self):
@@ -54,5 +81,12 @@ class Blocks(Base):
         Converts blocks to series.
         """
         from thunder.series.series import Series
-        values = self.values.values_to_keys(tuple(range(1, len(self.shape)))).unchunk()
+
+        if self.mode == 'spark':
+            values = self.values.values_to_keys(tuple(range(1, len(self.shape)))).unchunk()
+
+        if self.mode == 'local':
+            n = len(self.shape) - 1
+            values = self.values.transpose(tuple(range(1, n+1)) + (0,))
+
         return Series(values)


### PR DESCRIPTION
This PR adds two features to the Blocks object:

Adds a Blocks.map operation for applying array-to-array operations on a block by block basis.
Adds simple local mode support for blocks by considering the entire array to be a single block.