### PR TITLE
added map_as_series

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 scipy
 scikit-image
 boto
-bolt-python >= 1.0.0
+bolt-python >= 0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 scipy
 scikit-image
 boto
-bolt-python >= 0.3.2
+bolt-python >= 1.0.0

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy import arange, allclose, array
+from numpy import arange, allclose, array, mean, apply_along_axis
 
 from thunder.images.readers import fromlist
 from thunder.images.images import Images
@@ -168,6 +168,27 @@ def test_subtract(eng):
     sub = arange(24).reshape((4, 6))
     assert allclose(data.subtract(sub).toarray(), original - sub)
 
+def test_map_as_series(eng):
+    original = arange(4*3).reshape(4, 3)
+    data = fromlist(5*[original], engine=eng)
+
+    # function does not change size of series
+    def f(x):
+        return x - mean(x)
+    result = apply_along_axis(f, 0, data.toarray())
+
+    assert(data.map_as_series(f).toarray() ,result)
+    assert(data.map_as_series(f, value_size=5).toarray(), result)
+    assert(data.map_as_series(f, block_size=(2, 2)).toarray(), result)
+
+    # function does change size of series
+    def f(x):
+        return x[:-1]
+    result = apply_along_axis(f, 0, data.toarray())
+
+    assert(data.map_as_series(f).toarray(), result)
+    assert(data.map_as_series(f, value_size=4).toarray(), result)
+    assert(data.map_as_series(f, block_size=(2, 2)).toarray(), result)
 
 # def test_localcorr(eng):
 #     imgs = [

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -553,3 +553,34 @@ class Images(Data):
         """
         from thunder.images.writers import tobinary
         tobinary(self, path, prefix=prefix, overwrite=overwrite)
+
+    def map_as_series(self, func, value_size=None, block_size='150'):
+        """
+        Efficiently apply a function to each time series
+
+        Applies a function to each time series without transforming all the way
+        to a Series object, but using a Blocks object instead for increased
+        efficiency in the transformation back to Images.
+
+        func: function
+            Function to apply to each time series. Should take one-dimensional
+            ndarray and return the transformed one-dimensional ndarray.
+
+        value_size: int, optional, default=None
+            Size of the one-dimensional ndarray resulting from application of
+            func. If not supplied, will be automatically inferred for an extra
+            computational cost.
+
+        block_size : str, or tuple of block size per dimension,
+            String interpreted as memory size (e.g. "64M"). Tuple of ints interpreted as
+            "pixels per dimension".
+        """
+        blocks = self.toblocks(size=block_size)
+
+        if value_size is not None:
+            dims = list(blocks.blockshape)
+            dims[0] = value_size
+        else:
+            dims = None
+
+        return blocks.map(func, dims=dims).toimages()

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -63,7 +63,7 @@ class Images(Data):
         Parameters
         ----------
         size : str, or tuple of block size per dimension,
-            String interpreted as memory size (e.g. "64M"). Tuple of ints interpreted as
+            String interpreted as memory size (in megabytes, e.g. "64"). Tuple of ints interpreted as
             "pixels per dimension". Only valid in spark mode.
 
         Returns
@@ -572,8 +572,8 @@ class Images(Data):
             computational cost.
 
         block_size : str, or tuple of block size per dimension,
-            String interpreted as memory size (e.g. "64M"). Tuple of ints interpreted as
-            "pixels per dimension".
+            String interpreted as memory size (in megabytes e.g. "64"). Tuple of
+            ints interpreted as "pixels per dimension".
         """
         blocks = self.toblocks(size=block_size)
 


### PR DESCRIPTION
Adds a `Image.map_as_series` method that uses `Blocks` to apply a function to each series in an `Images` object and then turn the data back into an `Images` object -- avoids needing to transform the data all the way to a `Series` representation, which can be quite expensive to turn back into `Images` due to the high level of fragmentation that can occur when the total size of the spatial dimensions greatly outnumbers the size of the temporal dimension.