### PR TITLE
1.0.0 clean up code and docs for filtering on images

### DIFF
--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -438,7 +438,7 @@ class Images(Data):
         if not isinstance(neighborhood, int):
             raise ValueError("The neighborhood must be specified as an integer.")
 
-        from thunder.images.readers import fromarray
+        from thunder.images.readers import fromarray, fromrdd
         from numpy import corrcoef, concatenate
 
         nimages = self.shape[0]
@@ -451,10 +451,10 @@ class Images(Data):
         # ordered such that the first N images are the averaged ones.
         if self.mode == 'spark':
             combined = self.values.concatenate(blurred.values)
+            combinedImages = fromrdd(combined.tordd())
         else:
             combined = concatenate((self.values, blurred.values), axis=0)
-
-        combinedImages = fromarray(combined)
+            combinedImages = fromarray(combined)
 
         # Correlate the first N (averaged) records with the last N (original) records
         series = combinedImages.toseries()

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -332,28 +332,20 @@ class Images(Data):
         """
         Spatially smooth images with a gaussian filter.
 
-        Filtering will be applied to every image in the collection and can be applied
-        to either images or volumes. For volumes, if an single scalar sigma is passed,
-        it will be interpreted as the filter size in x and y, with no filtering in z.
+        Filtering will be applied to every image in the collection.
 
         parameters
         ----------
         sigma : scalar or sequence of scalars, default=2
             Size of the filter size as standard deviation in pixels. A sequence is interpreted
-            as the standard deviation for each axis. For three-dimensional data, a single
-            scalar is interpreted as the standard deviation in x and y, with no filtering in z.
+            as the standard deviation for each axis. A single scalar is applied equally to all
+            axes.
 
         order : choice of 0 / 1 / 2 / 3 or sequence from same set, optional, default = 0
             Order of the gaussian kernel, 0 is a gaussian, higher numbers correspond
             to derivatives of a gaussian.
         """
         from scipy.ndimage.filters import gaussian_filter
-
-        dims = self.dims
-        ndims = len(dims)
-
-        if ndims == 3 and size(sigma) == 1:
-            sigma = [sigma, sigma, sigma]
 
         return self.map(lambda v: gaussian_filter(v, sigma, order), dims=self.dims)
 

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -353,16 +353,14 @@ class Images(Data):
         """
         Spatially filter images using a uniform filter.
 
-        Filtering will be applied to every image in the collection and can be applied
-        to either images or volumes. For volumes, if an single scalar neighborhood is passed,
-        it will be interpreted as the filter size in x and y, with no filtering in z.
+        Filtering will be applied to every image in the collection.
 
         parameters
         ----------
         size: int, optional, default=2
             Size of the filter neighbourhood in pixels. A sequence is interpreted
-            as the neighborhood size for each axis. For three-dimensional data, a single
-            scalar is intrepreted as the neighborhood in x and y, with no filtering in z.
+            as the neighborhood size for each axis. A single scalar is applied equally to all
+            axes.
         """
         return self._image_filter(filter='uniform', size=size)
 
@@ -370,16 +368,14 @@ class Images(Data):
         """
         Spatially filter images using a median filter.
 
-        Filtering will be applied to every image in the collection and can be applied
-        to either images or volumes. For volumes, if an single scalar neighborhood is passed,
-        it will be interpreted as the filter size in x and y, with no filtering in z.
+        Filtering will be applied to every image in the collection.
 
         parameters
         ----------
         size: int, optional, default=2
             Size of the filter neighbourhood in pixels. A sequence is interpreted
-            as the neighborhood size for each axis. For three-dimensional data, a single
-            scalar is intrepreted as the neighborhood in x and y, with no filtering in z.
+            as the neighborhood size for each axis. A single scalar is applied equally to all
+            axes.
         """
         return self._image_filter(filter='median', size=size)
 


### PR DESCRIPTION
Previous filter operations on images expanded a scalar input parameter to two dimensions instead of three dimensions thereby treating 3D volumes as a collection of 2D images. This behaviour has been changed in 1.0.0, but the docs had not yet been updated to reflect it.

This PR updates the docs to indicate there is no more special handling of scalar input parameters, and removes some unnecessary code in the gaussian_filter method