### PR TITLE
commiting change

### DIFF
--- a/thunder/base.py
+++ b/thunder/base.py
@@ -376,7 +376,11 @@ class Data(Base):
             else:
                 mapped = asarray(list(map(func, reshaped)))
 
-            elem_shape = mapped[0].shape
+            try:
+                elem_shape = mapped[0].shape
+            except:
+                elem_shape = (1,)
+
             expand = list(elem_shape)
             expand = [1] if len(expand) == 0 else expand
 


### PR DESCRIPTION
Small fix to how `Base._map` functions in `local` mode. This allows the mapped function to return a singleton value (that is not wrapped in an `ndarray`) and still function. The resulting `Base.values` will still be an `ndarray` with the correct number of dimensions.