### PR TITLE
Series.flatten()

### DIFF
--- a/test/test_series.py
+++ b/test/test_series.py
@@ -1,7 +1,7 @@
 import pytest
 from numpy import allclose, arange, array, asarray, dot, cov
 
-from thunder.series.readers import fromlist
+from thunder.series.readers import fromlist, fromarray
 from thunder.series.timeseries import TimeSeries
 
 pytestmark = pytest.mark.usefixtures("eng")
@@ -27,6 +27,12 @@ def test_map_singletons(eng):
 def test_filter(eng):
     data = fromlist([array([1, 2]), array([3, 4])], engine=eng)
     assert allclose(data.filter(lambda x: x.sum() > 3).toarray(), [3, 4])
+
+def test_flatten(eng):
+    arr = arange(2*2*5).reshape(2, 2, 5)
+    data = fromarray(arr, engine=eng)
+    assert data.flatten().shape == (4, 5)
+    assert allclose(data.flatten().toarray(), arr.reshape(2*2, 5))
 
 
 def test_sample(eng):

--- a/thunder/series/series.py
+++ b/thunder/series/series.py
@@ -76,6 +76,15 @@ class Series(Data):
     def _constructor(self):
         return Series
 
+    def flatten(self):
+        """
+        Reshape all dimensions but the last into a single dimension
+        """
+
+        size = prod([s for i, s in enumerate(self.shape) if i in self.baseaxes])
+        newvalues = self.values.reshape(size, self.shape[-1])
+        return self._constructor(newvalues).__finalize__(self)
+
     def count(self):
         """
         Explicit count of the number of items.


### PR DESCRIPTION
Adds a `Series.flatten()` method that collapses all distributed axes onto a single axis.