### PR TITLE
rename local blocks to local chunks

### DIFF
--- a/thunder/blocks/blocks.py
+++ b/thunder/blocks/blocks.py
@@ -72,7 +72,7 @@ class Blocks(Base):
             values = self.values.values_to_keys((0,)).unchunk()
 
         if self.mode == 'local':
-            values = self.values.unblock()
+            values = self.values.unchunk()
 
         return Images(values)
 
@@ -86,7 +86,7 @@ class Blocks(Base):
             values = self.values.values_to_keys(tuple(range(1, len(self.shape)))).unchunk()
 
         if self.mode == 'local':
-            values = self.values.unblock()
+            values = self.values.unchunk()
             values = rollaxis(values, 0, values.ndim)
 
         return Series(values)

--- a/thunder/blocks/local.py
+++ b/thunder/blocks/local.py
@@ -6,30 +6,28 @@ from ..base import Base
 import logging
 
 
-class LocalBlocks:
+class LocalChunks:
     """
-    Light-weight class for a blocked local ndarray.
-
+    Simple helper class for a local chunked ndarray.
     """
 
     def __init__(self, values, shape, plan, dtype=None, padding=None):
         """
-        Create a blocked ndarray from the required values
+        Create a chunked ndarray.
 
         Parameters
         ----------
         values : ndarray (dtype 'object') or ndarrays
-            Array containing all of blocks
+            Array containing all the chunks.
 
         shape : tuple
-            Shape of the full unblocked array
+            Shape of the full unchunked array.
 
         plan : tuple
-            Shape of each block (excluding edge effects)
+            Shape of each chunk (excluding edge effects).
 
-        dtype : NumPy dtype, optional, default = None
-            dtype of blocks. If not given, will be inferred from first block
-
+        dtype : numpy dtype, optional, default = None
+            dtype of chunks. If not given, will be inferred from first chunk.
         """
         self.values = values
         self.shape = shape
@@ -43,30 +41,30 @@ class LocalBlocks:
     @property
     def first(self):
         """
-        first block
+        First chunk
         """
         return self.values[tuple(zeros(len(self.values.shape)))]
 
     @staticmethod
-    def block(arr, plan, padding=None):
+    def chunk(arr, plan, padding=None):
         """
-        Created a blocks array from a full array and a blocking plan
+        Created a chunked array from a full array and a chunking plan.
 
         Parameters
         ----------
         array : ndarray
-            Array that will be broken into blocks
+            Array that will be broken into chunks
 
         plan : tuple
-            Shape of desired blocks (up to edge effects)
+            Shape of desired chunks (up to edge effects)
 
         padding : tuple or int
-            Amount of padding along each dimensions for blocks. If an int, then
+            Amount of padding along each dimensions for chunks. If an int, then
             the same amount of padding is used for all dimensions
 
         Returns
         -------
-        LocalBlocks
+        LocalChunks
         """
 
         if padding is None:
@@ -95,11 +93,11 @@ class LocalBlocks:
             newarr[i] = vals[i]
         newsize = [b.shape[0]-1 for b in breaks]
         newarr = newarr.reshape(*newsize)
-        return LocalBlocks(newarr, shape, plan, dtype=arr.dtype, padding=padding)
+        return LocalChunks(newarr, shape, plan, dtype=arr.dtype, padding=padding)
 
-    def unblock(self):
+    def unchunk(self):
         """
-        Reconstitute the blocked array back into a full ndarray
+        Reconstitute the chunked array back into a full ndarray.
 
         Returns
         -------
@@ -139,7 +137,7 @@ class LocalBlocks:
 
         # check that no dimensions are dropped
         if len(value_shape) != len(self.plan):
-            raise NotImplementedError('map on ChunkedArray cannot drop dimensions')
+            raise NotImplementedError('map on chunked array cannot drop dimensions')
 
         # check that chunked dimensions did not change shape
         if any([value_shape[i] != self.plan[i] for i in blocked_dims]):
@@ -152,4 +150,4 @@ class LocalBlocks:
         mapped = empty(c, dtype=object)
         for i, a in enumerate(self.values.flatten()):
             mapped[i] = func(a)
-        return LocalBlocks(mapped.reshape(self.values.shape), newshape, value_shape, dtype)
+        return LocalChunks(mapped.reshape(self.values.shape), newshape, value_shape, dtype)

--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -4,7 +4,6 @@ from numpy import ndarray, arange, amax, amin, size, asarray, random, prod, \
 from itertools import product
 
 from ..base import Data
-from ..blocks.local import LocalBlocks
 
 
 class Images(Data):
@@ -74,17 +73,18 @@ class Images(Data):
             Only valid in spark mode.
         """
         from thunder.blocks.blocks import Blocks
+        from thunder.blocks.local import LocalChunks
 
         if self.mode == 'spark':
-            blocks = self.values.chunk(size).keys_to_values((0,))
+            chunks = self.values.chunk(size).keys_to_values((0,))
 
         if self.mode == 'local':
             if isinstance(size, str):
                 raise ValueError("block size must be a tuple for local mode")
             plan = (self.shape[0],) + tuple(size)
-            blocks = LocalBlocks.block(self.values, plan)
+            chunks = LocalChunks.chunk(self.values, plan)
 
-        return Blocks(blocks)
+        return Blocks(chunks)
 
     def toseries(self, size='150'):
         """


### PR DESCRIPTION
Better matches naming for distributed chunked array. This is entirely internal.