### PR TITLE
Map generic

### DIFF
--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy import arange, array, allclose, ones, float64
+from numpy import arange, array, allclose, ones, float64, asarray
 
 from thunder.images.readers import fromlist
 
@@ -90,3 +90,12 @@ def test_map(eng):
     map2 = data.toblocks((4, 2)).map(lambda x: 1.0 * x).toimages()
     assert map1.dtype == float64
     assert map2.dtype == float64
+
+def test_map_generic(eng):
+    a = arange(3*4).reshape((3, 4))
+    data = fromlist([a, a], engine=eng)
+    b = asarray(data.toblocks((2, 2)).map_generic(lambda x: [0, 1]))
+    assert b.shape == (2, 2)
+    assert b.dtype == object
+    truth = [v == [0, 1] for v in b.flatten()]
+    assert all(truth)

--- a/thunder/blocks/blocks.py
+++ b/thunder/blocks/blocks.py
@@ -60,7 +60,7 @@ class Blocks(Base):
         """
         Apply an arbitrary array -> object function to each blocks.
         """
-        return self.values.map_generic(func) 
+        return self.values.map_generic(func)[0] 
 
     def first(self):
         """

--- a/thunder/blocks/blocks.py
+++ b/thunder/blocks/blocks.py
@@ -56,6 +56,12 @@ class Blocks(Base):
         mapped = self.values.map(func, value_shape=dims, dtype=dtype)
         return self._constructor(mapped).__finalize__(self, noprop=('dtype',))
 
+    def map_generic(self, func):
+        """
+        Apply an arbitrary array -> object function to each blocks.
+        """
+        return self.values.map_generic(func) 
+
     def first(self):
         """
         Return the first element.

--- a/thunder/blocks/local.py
+++ b/thunder/blocks/local.py
@@ -160,3 +160,12 @@ class LocalBlocks:
         for i, a in enumerate(self.values.flatten()):
             mapped[i] = func(a)
         return LocalBlocks(mapped.reshape(self.values.shape), newshape, value_shape, dtype)
+
+    def map_generic(self, func):
+
+        shape = self.values.shape
+        n = prod(shape)
+        arr = empty(n, dtype=object)
+        for i, x in enumerate(self.values.flatten()):
+            arr[i] = func(x)
+        return arr.reshape(shape)


### PR DESCRIPTION
Adds `Blocks.map_generic` which allows for general block -> object transformations.