### PR TITLE
tiffs with npages not dividing by pageCount will give a warning instead an error

### DIFF
--- a/test/test_images_io.py
+++ b/test/test_images_io.py
@@ -114,6 +114,16 @@ def test_from_tif_multi_planes(eng):
     assert [x.sum() for x in data.toarray()] == [1140006, 1119161, 1098917]
 
 
+def test_from_tif_multi_planes_discard_extra(eng):
+    path = os.path.join(resources, 'multilayer_tif', 'dotdotdot_lzw.tif')
+    data = fromtif(path, nplanes=2, engine=eng, discard_extra=True)
+    assert data.shape[0] == 1
+    assert data.shape[1] == 2
+    with pytest.raises(BaseException) as error_msg:
+        data = fromtif(path, nplanes=2, engine=eng, discard_extra=False)
+    assert 'nplanes' in str(error_msg.value)
+
+
 def test_from_tif_multi_planes_many(eng):
     path = os.path.join(resources, 'multilayer_tif', 'dotdotdot_lzw*.tif')
     data = fromtif(path, nplanes=3, engine=eng)

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -149,9 +149,9 @@ class LocalParallelReader(object):
         if spark and isinstance(self.engine, spark):
             npartitions = min(npartitions, nfiles) if npartitions else nfiles
             rdd = self.engine.parallelize(enumerate(files), npartitions)
-            return rdd.map(lambda kv: (kv[0], readlocal(kv[1])))
+            return rdd.map(lambda kv: (kv[0], readlocal(kv[1]), kv[1]))
         else:
-            return [(k, readlocal(v)) for k, v in enumerate(files)]
+            return [(k, readlocal(v), v) for k, v in enumerate(files)]
 
 
 class LocalFileReader(object):


### PR DESCRIPTION
Alternative implementation to #279 
Thinking of adding a flag to `fromtif()` that would default to the current behavior of rising an error.
Also I am sending the warning using the `warning` module, I saw another way using the spark logger:
```python 
log4jLogger = sc._jvm.org.apache.log4j
LOGGER = log4jLogger.LogManager.getLogger(__name__)
LOGGER.warning("number of planes...")
```
@sofroniewn @freeman-lab What do you guys think?
  