### PR TITLE
BotoParallelReader bug 

### DIFF
--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -391,7 +391,7 @@ class BotoParallelReader(BotoClient):
                     idx, keyName = kv
                     key = bucket.get_key(keyName)
                     buf = key.get_contents_as_string()
-                    yield idx, buf
+                    yield idx, buf, keyName
 
             npartitions = min(npartitions, self.nfiles) if npartitions else self.nfiles
             rdd = self.engine.parallelize(enumerate(keylist), npartitions)
@@ -412,7 +412,7 @@ class BotoParallelReader(BotoClient):
                 idx, keyName = kv
                 key = bucket.get_key(keyName)
                 buf = key.get_contents_as_string()
-                return idx, buf
+                return idx, buf, keyName
 
             return [getsplit(kv) for kv in enumerate(keylist)]
 

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -388,10 +388,10 @@ class BotoParallelReader(BotoClient):
                     raise NotImplementedError("No file reader implementation for URL scheme " + scheme)
 
                 for kv in kvIter:
-                    idx, keyName = kv
-                    key = bucket.get_key(keyName)
+                    idx, keyname = kv
+                    key = bucket.get_key(keyname)
                     buf = key.get_contents_as_string()
-                    yield idx, buf, keyName
+                    yield idx, buf, keyname
 
             npartitions = min(npartitions, self.nfiles) if npartitions else self.nfiles
             rdd = self.engine.parallelize(enumerate(keylist), npartitions)


### PR DESCRIPTION
Trying to run
`data = td.images.fromexample(name='mouse',engine=None)`
fails due to a change from  #313  as the accessor function expects 3 params.
This PR fixes that, still don't know if related to #327
There are no tests for the BotoParallelReader, seems very hard to mock AWS.
@freeman-lab  Is there another way? 