### PR TITLE
Fix misspelled "labels" in series.py

### DIFF
--- a/thunder/series/series.py
+++ b/thunder/series/series.py
@@ -140,7 +140,7 @@ class Series(Data):
         if engine is None:
             raise ValueError('Must provide SparkContext')
 
-        return fromarray(self.toarray(), index=self.index, labels=self.lables, engine=engine)
+        return fromarray(self.toarray(), index=self.index, labels=self.labels, engine=engine)
 
     def sample(self, n=100, seed=None):
         """


### PR DESCRIPTION
Tried to convert a series to spark mode and got an error. Looks like labels was just misspelled.