### PR TITLE
bug fix in images.toseries() 'auto' if images length > 100000

### DIFF
--- a/thunder/images/images.py
+++ b/thunder/images/images.py
@@ -105,7 +105,7 @@ class Images(Data):
         from thunder.series.series import Series
 
         if chunk_size is 'auto':
-            chunk_size = str(int(100000.0/self.shape[0]))
+            chunk_size = str(max([int(100000.0/self.shape[0]), 1]))
 
         n = len(self.shape) - 1
         index = arange(self.shape[0])


### PR DESCRIPTION
fixes #347 