### PR TITLE
replace skimage with tiffile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
-scikit-image
-boto
+boto >= 2.36.0
 bolt-python >= 0.7.0
+tifffile >= 0.9.2

--- a/test/test_images_io.py
+++ b/test/test_images_io.py
@@ -264,8 +264,24 @@ def test_to_tif(tmpdir, eng):
     assert sorted(files) == ['image-00000.tif', 'image-00001.tif']
 
 
-def test_to_tif_roundtrip(tmpdir, eng):
+def test_to_tif_roundtrip_multipage(tmpdir, eng):
+    a = [arange(24, dtype='int16').reshape((2, 3, 4)), arange(24, dtype='int16').reshape((2, 3, 4))]
+    data = fromlist(a, engine=eng)
+    data.totif(os.path.join(str(tmpdir), 'images'), prefix='image')
+    loaded = fromtif(os.path.join(str(tmpdir), 'images'))
+    assert allclose(data.toarray(), loaded.toarray())
+
+
+def test_to_tif_roundtrip_8bit(tmpdir, eng):
     a = [arange(8, dtype='uint8').reshape((4, 2))]
+    data = fromlist(a, engine=eng)
+    data.totif(os.path.join(str(tmpdir), 'images'), prefix='image')
+    loaded = fromtif(os.path.join(str(tmpdir), 'images'))
+    assert allclose(data.toarray(), loaded.toarray())
+
+
+def test_to_tif_roundtrip_16bit(tmpdir, eng):
+    a = [arange(8, dtype='uint16').reshape((4, 2))]
     data = fromlist(a, engine=eng)
     data.totif(os.path.join(str(tmpdir), 'images'), prefix='image')
     loaded = fromtif(os.path.join(str(tmpdir), 'images'))

--- a/thunder/images/readers.py
+++ b/thunder/images/readers.py
@@ -356,7 +356,7 @@ def fromtif(path, ext='tif', start=None, stop=None, recursive=False, nplanes=Non
         If True and nplanes doesn't divide by the number of pages in a multi-page tiff, the reminder will
         be discarded and a warning will be shown. If False, it will raise an error
     """
-    import skimage.external.tifffile as tifffile
+    from tifffile import TiffFile
 
     if nplanes is not None and nplanes <= 0:
         raise ValueError('nplanes must be positive if passed, got %d' % nplanes)
@@ -364,7 +364,7 @@ def fromtif(path, ext='tif', start=None, stop=None, recursive=False, nplanes=Non
     def getarray(idx_buffer_filename):
         idx, buf, fname = idx_buffer_filename
         fbuf = BytesIO(buf)
-        tfh = tifffile.TiffFile(fbuf)
+        tfh = TiffFile(fbuf)
         ary = tfh.asarray()
         pageCount = ary.shape[0]
         if nplanes is not None:

--- a/thunder/images/writers.py
+++ b/thunder/images/writers.py
@@ -41,7 +41,7 @@ def totif(images, path, prefix="image", overwrite=False, credentials=None):
         raise ValueError("Only 2D or 3D images can be exported to tif, "
                          "images are %d-dimensional." % len(value_shape))
 
-    from scipy.misc import imsave
+    from tifffile import imsave
     from io import BytesIO
     from thunder.writers import get_parallel_writer
 
@@ -49,7 +49,7 @@ def totif(images, path, prefix="image", overwrite=False, credentials=None):
         key, img = kv
         fname = prefix+"-"+"%05d.tif" % int(key)
         bytebuf = BytesIO()
-        imsave(bytebuf, img, format='TIFF')
+        imsave(bytebuf, img)
         return fname, bytebuf.getvalue()
 
     writer = get_parallel_writer(path)(path, overwrite=overwrite, credentials=credentials)


### PR DESCRIPTION
This PR switches to use `tifffile` for tif writing which means we can remove the dependency on `skimage` (we were only using it for its tif handling).

This means that `images.totif` now supports 8-bit and 16-bit data and both single and multi page tifs.

cc @sofroniewn @boazmohar @d-v-b 