### PR TITLE
remove unused conda installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create --yes -q -n test python=$TRAVIS_PYTHON_VERSION pip numpy scipy scikit-learn scikit-image matplotlib pytest boto
+  - conda create --yes -q -n test python=$TRAVIS_PYTHON_VERSION pip numpy scipy pytest boto
   - source activate test
   - pip install .
   - pip install -r requirements-dev.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy
 six
+pillow>=2.1.0
 boto >= 2.36.0
 bolt-python >= 0.7.0
 tifffile >= 0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 scipy
+six
 boto >= 2.36.0
 bolt-python >= 0.7.0
 tifffile >= 0.9.2


### PR DESCRIPTION
Cleans up our dependency handling by removing unused packages from the `conda` install step on `travis` so we can properly check dependencies.