### PR TITLE
Adds tiff files when using images.fromtif default 'tif extension

### DIFF
--- a/test/test_images_io.py
+++ b/test/test_images_io.py
@@ -284,6 +284,19 @@ def test_to_tif_roundtrip_multipage(tmpdir, eng):
     assert allclose(data.toarray(), loaded.toarray())
 
 
+def test_to_tiff_roundtrip_multipage(tmpdir, eng):
+    a = [arange(24, dtype='int16').reshape((2, 3, 4)), arange(24, dtype='int16').reshape((2, 3, 4))]
+    data = fromlist(a, engine=eng)
+    data.totif(os.path.join(str(tmpdir), 'images'), prefix='image')
+    # rename to tiff
+    for filename in glob.iglob(os.path.join(str(tmpdir), 'images', '*.tif')):
+        os.rename(filename, filename[:-4] + '.tiff')
+    files = [os.path.basename(f) for f in glob.glob(str(tmpdir) + '/images/image*')]
+    assert sorted(files) == ['image-00000.tiff', 'image-00001.tiff']
+    loaded = fromtif(os.path.join(str(tmpdir), 'images'))
+    assert allclose(data.toarray(), loaded.toarray())
+
+
 def test_to_tif_roundtrip_8bit(tmpdir, eng):
     a = [arange(8, dtype='uint8').reshape((4, 2))]
     data = fromlist(a, engine=eng)

--- a/test/test_images_io.py
+++ b/test/test_images_io.py
@@ -316,6 +316,6 @@ def test_to_tif_roundtrip_16bit(tmpdir, eng):
 def test_from_example(eng):
     return
     data = fromexample('fish', engine=eng)
-    assert allclose(data.shape, (20, 76, 87, 2))
+    assert allclose(data.shape, (20, 2, 76, 87))
     data = fromexample('mouse', engine=eng)
     assert allclose(data.shape, (20, 64, 64))

--- a/test/test_readers.py
+++ b/test/test_readers.py
@@ -74,3 +74,24 @@ def test_local_recursive_nested(tmpdir):
     make(tmpdir, filenames)
     actual = LocalFileReader().list(str(tmpdir), recursive=True)
     assert parse(actual) == expected
+
+
+def test_tif_tiff_flat(tmpdir):
+    filenames = ['b.tif', 'a.tif', 'c.tiff']
+    expected = ['a.tif', 'b.tif', 'c.tiff']
+    make(tmpdir, filenames)
+    actual = LocalParallelReader().list(str(tmpdir), ext='tif', recursive=False)
+    assert parse(actual) == expected
+    actual = LocalParallelReader().list(str(tmpdir), ext='tif', recursive=True)
+    assert parse(actual) == expected
+
+
+def test_tif_tiff_recursive(tmpdir):
+    filenames = ['foo/b.tif', 'foo/bar/q.tiff', 'bar/a', 'c.tif', 'd.tiff']
+    expected = ['c.tif', 'd.tiff']
+    make(tmpdir, filenames)
+    actual = LocalParallelReader().list(str(tmpdir), ext='tif', recursive=False)
+    assert parse(actual) == expected
+    expected = ['c.tif', 'd.tiff', 'b.tif', 'q.tiff']
+    actual = LocalParallelReader().list(str(tmpdir), ext='tif', recursive=True)
+    assert parse(actual) == expected

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -93,7 +93,7 @@ def listflat(path, ext=None):
         if ext:
             files = glob.glob(os.path.join(path, '*.' + ext))
             if ext == 'tif':
-                files.append(glob.glob(os.path.join(path, '*.' + ext)))
+                files.append(glob.glob(os.path.join(path, '*.' + 'tiff')))
         else:
             files = [os.path.join(path, fname) for fname in os.listdir(path)]
     else:

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -77,6 +77,8 @@ def listrecursive(path, ext=None):
     for root, dirs, files in os.walk(path):
         if ext:
             files = fnmatch.filter(files, '*.' + ext)
+            if ext == 'tif':
+                files = files + fnmatch.filter(files, '*.' + 'tiff')
         for filename in files:
             filenames.add(os.path.join(root, filename))
     filenames = list(filenames)
@@ -90,6 +92,8 @@ def listflat(path, ext=None):
     if os.path.isdir(path):
         if ext:
             files = glob.glob(os.path.join(path, '*.' + ext))
+            if ext == 'tif':
+                files.append(glob.glob(os.path.join(path, '*.' + ext)))
         else:
             files = [os.path.join(path, fname) for fname in os.listdir(path)]
     else:
@@ -342,6 +346,8 @@ class BotoParallelReader(BotoClient):
         keylist = [key.name for key in keys]
         if ext:
             keylist = [keyname for keyname in keylist if keyname.endswith(ext)]
+            if ext == 'tif':
+                keylist.append([keyname for keyname in keylist if keyname.endswith('tiff')])
         keylist.sort()
         keylist = select(keylist, start, stop)
 

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -76,9 +76,11 @@ def listrecursive(path, ext=None):
     filenames = set()
     for root, dirs, files in os.walk(path):
         if ext:
-            files = fnmatch.filter(files, '*.' + ext)
             if ext == 'tif':
-                files = files + fnmatch.filter(files, '*.' + 'tiff')
+                tmp = fnmatch.filter(files, '*.' + 'tiff')
+                files = tmp + fnmatch.filter(files, '*.' + 'tif')
+            else:
+                files = fnmatch.filter(files, '*.' + ext)
         for filename in files:
             filenames.add(os.path.join(root, filename))
     filenames = list(filenames)
@@ -93,13 +95,13 @@ def listflat(path, ext=None):
         if ext:
             files = glob.glob(os.path.join(path, '*.' + ext))
             if ext == 'tif':
-                files.append(glob.glob(os.path.join(path, '*.' + 'tiff')))
+                files = files + glob.glob(os.path.join(path, '*.tiff'))
         else:
             files = [os.path.join(path, fname) for fname in os.listdir(path)]
     else:
         files = glob.glob(path)
     # filter out directories
-    files = [fpath for fpath in files if not os.path.isdir(fpath)]
+    files = [fpath for fpath in files if not isinstance(fpath, list) and not os.path.isdir(fpath)]
     return sorted(files)
 
 def uri_to_path(uri):

--- a/thunder/readers.py
+++ b/thunder/readers.py
@@ -76,7 +76,7 @@ def listrecursive(path, ext=None):
     filenames = set()
     for root, dirs, files in os.walk(path):
         if ext:
-            if ext == 'tif':
+            if ext == 'tif' or ext == 'tiff':
                 tmp = fnmatch.filter(files, '*.' + 'tiff')
                 files = tmp + fnmatch.filter(files, '*.' + 'tif')
             else:
@@ -93,9 +93,11 @@ def listflat(path, ext=None):
     """
     if os.path.isdir(path):
         if ext:
-            files = glob.glob(os.path.join(path, '*.' + ext))
-            if ext == 'tif':
+            if ext == 'tif' or ext == 'tiff':
+                files = glob.glob(os.path.join(path, '*.tif'))
                 files = files + glob.glob(os.path.join(path, '*.tiff'))
+            else:
+                files = glob.glob(os.path.join(path, '*.' + ext))
         else:
             files = [os.path.join(path, fname) for fname in os.listdir(path)]
     else:
@@ -347,9 +349,12 @@ class BotoParallelReader(BotoClient):
             bucket, parse[2], prefix=parse[3], postfix=parse[4], recursive=recursive)
         keylist = [key.name for key in keys]
         if ext:
-            keylist = [keyname for keyname in keylist if keyname.endswith(ext)]
-            if ext == 'tif':
+            if ext == 'tif' or ext == 'tiff':
+                keylist = [keyname for keyname in keylist if keyname.endswith('tif')]
                 keylist.append([keyname for keyname in keylist if keyname.endswith('tiff')])
+            else:
+                keylist = [keyname for keyname in keylist if keyname.endswith(ext)]
+
         keylist.sort()
         keylist = select(keylist, start, stop)
 


### PR DESCRIPTION
Solves #341 
@freeman-lab What is a good default behavior as this is implemented now, it will not enable you to select either tif or tiff from your folders.
I could change the default `ext='tif'` to `'ext='tifs' to make it possible, What do you think?
Also didn't test with s3, any thoughts as to how?
