### PR TITLE
removes pillow from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 scipy
 six
-pillow>=2.1.0
 boto >= 2.36.0
 bolt-python >= 0.7.0
 tifffile >= 0.9.2


### PR DESCRIPTION
pillow was previously used to write TIFFs, but has since been replaced with tifffile.